### PR TITLE
Add a quoteVolume field to the Ticker type.

### DIFF
--- a/src/exchange_adapters/base.ts
+++ b/src/exchange_adapters/base.ts
@@ -45,6 +45,11 @@ export type Ticker = PriceMetadata & {
    */
   low?: BigNumber
   open?: BigNumber
+  /**
+   * the total volume of the quote currency traded in the period considered. This
+   * is generally the last 24 hours, but it could vary between exchanges.
+   */
+  quoteVolume: BigNumber
   timestamp: number
 }
 

--- a/src/exchange_adapters/binance.ts
+++ b/src/exchange_adapters/binance.ts
@@ -71,6 +71,7 @@ export class BinanceAdapter extends BaseExchangeAdapter implements ExchangeAdapt
       lastPrice: this.safeBigNumberParse(json.lastPrice)!,
       low: this.safeBigNumberParse(json.lowPrice),
       open: this.safeBigNumberParse(json.openPrice),
+      quoteVolume: this.safeBigNumberParse(json.quoteVolume)!,
       timestamp: this.safeBigNumberParse(json.closeTime)?.toNumber()!,
     }
     this.verifyTicker(ticker)

--- a/src/exchange_adapters/bittrex.ts
+++ b/src/exchange_adapters/bittrex.ts
@@ -72,6 +72,7 @@ export class BittrexAdapter extends BaseExchangeAdapter {
       ask: this.safeBigNumberParse(tickerJson.askRate)!,
       lastPrice: this.safeBigNumberParse(tickerJson.lastTradeRate)!,
       baseVolume: this.safeBigNumberParse(summaryJson.volume)!,
+      quoteVolume: this.safeBigNumberParse(summaryJson.quoteVolume)!,
     }
     this.verifyTicker(ticker)
     return ticker

--- a/src/exchange_adapters/okcoin.ts
+++ b/src/exchange_adapters/okcoin.ts
@@ -64,6 +64,7 @@ export class OKCoinAdapter extends BaseExchangeAdapter {
       lastPrice: this.safeBigNumberParse(json.last)!,
       low: this.safeBigNumberParse(json.low_24h),
       open: this.safeBigNumberParse(json.open_24h),
+      quoteVolume: this.safeBigNumberParse(json.quote_volume_24h)!,
       timestamp: this.safeDateParse(json.timestamp)!,
     }
     this.verifyTicker(ticker)

--- a/test/data_aggregator_testdata_utils.ts
+++ b/test/data_aggregator_testdata_utils.ts
@@ -60,6 +60,25 @@ const testTickerVolumes = [
   [1000, 2000, 2000],
 ]
 
+const testTickerQuoteVolumes = [
+  [1000, 40000, 12000],
+  [1000000, 12000, 40000],
+  [1000, 2000, 2000],
+  [1000, 2000, 2000],
+  [1000, 2000, 2000],
+  [-1000, 2000, 2000],
+  [1000, 2000, 2000],
+  [1000, 2000, 2000],
+  [1000, 2000, 2000],
+  [1000, 2000, 2000],
+  [1000, 2000, 1000000],
+  [100000, 60000, 40000],
+  [1000, 2000, 2000],
+  [1000, 2000, 2000],
+  [-1000, -2000, -2000],
+  [1000, 2000, 2000],
+]
+
 const testTickerExchanges = [
   [Exchange.COINBASE, Exchange.OKCOIN, Exchange.BITTREX],
   [Exchange.COINBASE, Exchange.OKCOIN, Exchange.BITTREX],
@@ -90,6 +109,7 @@ export const testTickerArray: Ticker[][] = testTickerAsks.map((row, rowIndex) =>
       bid: new BigNumber(testTickerBids[rowIndex][colIndex]),
       lastPrice: new BigNumber(testTickerBids[rowIndex][colIndex] - 0.03),
       baseVolume: new BigNumber(testTickerVolumes[rowIndex][colIndex]),
+      quoteVolume: new BigNumber(testTickerQuoteVolumes[rowIndex][colIndex]),
     }
     return thisTicker
   })
@@ -105,5 +125,6 @@ export function generateGoodTicker(exchange: Exchange): Ticker {
     bid: new BigNumber(1.05),
     lastPrice: new BigNumber(1.07),
     baseVolume: new BigNumber(1000),
+    quoteVolume: new BigNumber(1070),
   }
 }

--- a/test/exchange_adapters/binance.test.ts
+++ b/test/exchange_adapters/binance.test.ts
@@ -54,6 +54,7 @@ describe('BinanceAdapter', () => {
         lastPrice: new BigNumber(0.00008174),
         low: new BigNumber(0.00007948),
         open: new BigNumber(0.00008059),
+        quoteVolume: new BigNumber(12.22296665),
         timestamp: 1614690999055,
       })
     })

--- a/test/exchange_adapters/bittrex.test.ts
+++ b/test/exchange_adapters/bittrex.test.ts
@@ -52,6 +52,7 @@ describe('BittrexAdapter', () => {
         ask: new BigNumber(213.834),
         lastPrice: new BigNumber(213.762),
         baseVolume: new BigNumber(3335.48514449),
+        quoteVolume: new BigNumber(711062.81323057),
       })
     })
     it('throws an error when a required BigNumber field is missing', () => {

--- a/test/exchange_adapters/coinbase.test.ts
+++ b/test/exchange_adapters/coinbase.test.ts
@@ -120,6 +120,7 @@ describe('CoinbaseAdapter', () => {
         bid: new BigNumber(200.93),
         close: new BigNumber(200.81),
         lastPrice: new BigNumber(200.81),
+        quoteVolume: new BigNumber(513386.930205),
         timestamp: 1590497345049,
       })
     })

--- a/test/exchange_adapters/okcoin.test.ts
+++ b/test/exchange_adapters/okcoin.test.ts
@@ -50,6 +50,7 @@ describe('OKCoinAdapter', () => {
         lastPrice: new BigNumber(200.81),
         low: new BigNumber(200.36),
         open: new BigNumber(203.43),
+        quoteVolume: new BigNumber(519342.82),
         timestamp: 1590497345049,
       })
     })


### PR DESCRIPTION
## Description

Changes the ExchangeAdapter interface by adding a `quoteVolume` field to the `Ticker` type returned by `fetchTicker()`. This field is populated with the quote currency volume (quote notional) on each adapter, except for Coinbase, as it's not provided by its API. Coinbase's adapter calculates quoteVolume from baseVolume and lastPrice.

## Tested

Unit/integration tests modified to support the new field.

## Related issues

- Needed for #11.

## Backwards compatibility

Backwards compatible -- new field added to a type, all usages of the type updated.