### PR TITLE
Improve PRICE_SOURCES env var config validation.

### DIFF
--- a/src/envvar_utils.ts
+++ b/src/envvar_utils.ts
@@ -1,3 +1,4 @@
+import { strict as assert } from 'assert'
 import { ensureLeading0x, isValidAddress } from '@celo/utils/lib/address'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
@@ -70,7 +71,15 @@ interface OrientedExchangePairConfig {
 
 type PriceSourceConfig = OrientedExchangePairConfig[]
 
+function assertPropertyType<T, K extends keyof T>(object: T, property: K, type: string) {
+  const value = object[property]
+  assert(typeof value === type, `${property} is ${value} and not of type ${type}`)
+}
+
 function parseOrientedExchangePair(config: OrientedExchangePairConfig): OrientedExchangePair {
+  assertPropertyType(config, 'exchange', 'string')
+  assertPropertyType(config, 'symbol', 'string')
+  assertPropertyType(config, 'toInvert', 'boolean')
   return {
     exchange: Exchange[config.exchange as keyof typeof Exchange],
     symbol: OracleCurrencyPair[config.symbol as keyof typeof OracleCurrencyPair],


### PR DESCRIPTION
Check that all OrientedExchangePairConfig properties have the right type
after an object is loaded from a YAML string.

## Description

Currently an YAML loaded OrientedExchangePairConfig object might have some of its fields `undefined`. This PR ensures it doesn't happen by asserting the properties types, hence interrupting the execution if the price sources are misconfigured.

## Tested

Tested on a local testnet.

## Related issues

- #11 

## Backwards compatibility

No interface changes.
