### PR TITLE
CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ reference:
 defaults: &defaults
   working_directory: ~/app
   docker:
-    - image: celohq/node10-gcloud:v2
+    - image: cimg/node:12.22.2
   environment:
     # To avoid ENOMEM problem when running node
     NODE_OPTIONS: '--max-old-space-size=4096'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,8 @@ jobs:
             set -euo pipefail
             cd ~/app
             set -v
-            # To get the "master" branch mapping
-            git checkout master
+            # To get the "main" branch mapping
+            git checkout main
             git checkout ${CIRCLE_BRANCH}
             # Verify that following commands work, they are later called in the incremental testing script
             # There output does not matter here, the fact that they finish successfully does.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           name: jest tests
           command: |
             mkdir -p test-results/jest
-            yarn run test
+            yarn run test --maxWorkers 2
       - store_test_results:
           path: test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,125 @@
+# adapted from https://github.com/CircleCI-Public/circleci-demo-react-native
+# and https://github.com/facebook/react-native/blob/master/.circleci/config.yml
+
+version: 2.1
+reference:
+  workspace: &workspace ~/src
+
+defaults: &defaults
+  working_directory: ~/app
+  docker:
+    - image: celohq/node10-gcloud:v2
+  environment:
+    # To avoid ENOMEM problem when running node
+    NODE_OPTIONS: '--max-old-space-size=4096'
+
+commands:
+  yarn_install:
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            # Deals with yarn install flakiness which can come due to yarnpkg.com being
+            # unreliable. For example, https://circleci.com/gh/celo-org/celo-monorepo/82685
+            yarn install || yarn install
+      - run:
+          name: Fail if someone forgot to commit "yarn.lock"
+          command: |
+            if [[ $(git status --porcelain) ]]; then
+              git --no-pager diff
+              echo "There are git differences after running yarn install"
+              exit 1
+            fi
+jobs:
+  install_dependencies:
+    <<: *defaults
+    # Source: https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    resource_class: medium+
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+            - source-v1-{{ .Branch }}-
+            - source-v1-
+
+      - checkout
+
+      - save_cache:
+          key: source-v1-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - '.git'
+
+      - run:
+          name: Verify setup for incremental testing
+          command: |
+            set -euo pipefail
+            cd ~/app
+            set -v
+            # To get the "master" branch mapping
+            git checkout master
+            git checkout ${CIRCLE_BRANCH}
+            # Verify that following commands work, they are later called in the incremental testing script
+            # There output does not matter here, the fact that they finish successfully does.
+            git rev-parse --abbrev-ref HEAD
+      - attach_workspace:
+          at: ~/app
+
+      - yarn_install
+
+      - run:
+          name: Build packages
+          command: |
+            yarn build
+      - run:
+          name: Check licenses
+          command: |
+            if [ ! -e ~/.tmp/yarn_deps_have_changed ]; then
+              # Internally `yarn check-licenses` downloads dependencies into its cache again even if node_modules are up-to-date
+              # which happens when we've restored our cached node_modules.
+              # Making `yarn check-licenses` take ~45secs instead of ~3secs (depending on network conditions and build machine)
+              # So here we skip checking when it's unnecessary
+              echo "Skipping checking licenses, dependencies haven't changed"
+              exit 0
+            fi
+            yarn check-licenses
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  lint-checks:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/app
+      # If this fails, fix it with
+      # `./node_modules/.bin/prettier --config .prettierrc.js --write '**/*.+(ts|tsx|js|jsx)'`
+      - run: yarn run prettify:diff
+      - run: yarn run lint
+      - run: yarn run lint:tests
+
+  general-test:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/app
+
+      - run:
+          name: jest tests
+          command: |
+            mkdir -p test-results/jest
+            yarn run test
+      - store_test_results:
+          path: test-results
+
+workflows:
+  version: 2
+  celo-oracle-build:
+    jobs:
+      - install_dependencies
+      - lint-checks:
+          requires:
+            - install_dependencies
+      - general-test:
+          requires:
+            - install_dependencies


### PR DESCRIPTION
## Description

This PR adds a CircleCI config, based on the original one used before the repo was public. It allows the tests and other checks to run on CircleCI, rather than relying on google cloud build. Tests can now run for PRs made from forks of the repo, which is necessary for broader participation.

## Other changes

n/a

## Tested

Verified that this causes tests to run on CircleCI and update the status here in github
