### PR TITLE
Set jest --maxWorkers to 2.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           name: jest tests
           command: |
             mkdir -p test-results/jest
-            yarn run test
+            yarn run test --maxWorkers 2
       - store_test_results:
           path: test-results
 


### PR DESCRIPTION
As letting it pick the number of workers from the CPU count might not
work as expected on a CI environment (see
https://jestjs.io/docs/cli#--maxworkersnumstring).