### PR TITLE
Small CI Tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,17 +22,12 @@ commands:
             - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Install dependencies
-          command: |
-            # Deals with yarn install flakiness which can come due to yarnpkg.com being
-            # unreliable. For example, https://circleci.com/gh/celo-org/celo-monorepo/82685
-            # --cache-folder sets yarn's cache to the a folder being stored/loaded
-            # on CircleCI's cache.
-            # --frozen-lockfile instructs yarn not to generate a lockfile, and to
-            # return an error if the lockfile present does not match the
-            # dependencies.
-            yarn install --frozen-lockfile --cache-folder ~/.cache/yarn || yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+          # --cache-folder sets yarn's cache to the a folder being stored/loaded
+          # on CircleCI's cache.
+          # --frozen-lockfile instructs yarn not to generate a lockfile, and to
           # return an error if the lockfile present does not match the
           # dependencies.
+          command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
       - save_cache:
           name: Saving yarn cache
           key: yarn-packages-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,15 +27,12 @@ commands:
             # unreliable. For example, https://circleci.com/gh/celo-org/celo-monorepo/82685
             # --cache-folder sets yarn's cache to the a folder being stored/loaded
             # on CircleCI's cache.
-            yarn install --cache-folder ~/.cache/yarn || yarn install --cache-folder ~/.cache/yarn
-      - run:
-          name: Fail if someone forgot to commit "yarn.lock"
-          command: |
-            if [[ $(git status --porcelain) ]]; then
-              git --no-pager diff
-              echo "There are git differences after running yarn install"
-              exit 1
-            fi
+            # --frozen-lockfile instructs yarn not to generate a lockfile, and to
+            # return an error if the lockfile present does not match the
+            # dependencies.
+            yarn install --frozen-lockfile --cache-folder ~/.cache/yarn || yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+          # return an error if the lockfile present does not match the
+          # dependencies.
       - save_cache:
           name: Saving yarn cache
           key: yarn-packages-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,18 @@ defaults: &defaults
 commands:
   yarn_install:
     steps:
+      - restore_cache:
+          name: Restoring yarn cache
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Install dependencies
           command: |
             # Deals with yarn install flakiness which can come due to yarnpkg.com being
             # unreliable. For example, https://circleci.com/gh/celo-org/celo-monorepo/82685
-            yarn install || yarn install
+            # --cache-folder sets yarn's cache to the a folder being stored/loaded
+            # on CircleCI's cache.
+            yarn install --cache-folder ~/.cache/yarn || yarn install --cache-folder ~/.cache/yarn
       - run:
           name: Fail if someone forgot to commit "yarn.lock"
           command: |
@@ -30,6 +36,11 @@ commands:
               echo "There are git differences after running yarn install"
               exit 1
             fi
+      - save_cache:
+          name: Saving yarn cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
 jobs:
   install_dependencies:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
     resource_class: medium+
     steps:
       - restore_cache:
+          name: Loading git cache
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
             - source-v1-{{ .Branch }}-
@@ -48,6 +49,7 @@ jobs:
       - checkout
 
       - save_cache:
+          name: Saving git cache
           key: source-v1-{{ .Branch }}-{{ .Revision }}
           paths:
             - '.git'


### PR DESCRIPTION
## Description

Currently the `yarn install` step of the CI build does not use a cache. This PR introduces the usage of CircleCI's caching to store yarn's cache and to re-use it in between runs.

## Tested

Builds triggered on CircleCI and they successfully passed.
