### PR TITLE
Change ACR push to celoprod.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,9 +137,9 @@ workflows:
             - lint-checks
             - general-test
           dockerfile: Dockerfile
-          login-server-name: celotestnet.azurecr.io
-          registry-name: celotestnet
-          repo: testnet/oracle
+          login-server-name: celoprod.azurecr.io
+          registry-name: celoprod
+          repo: oracle
           tag: $CIRCLE_SHA1
           filters:
             branches:


### PR DESCRIPTION
## Description

The CircleCI build currently pushes docker images to the `celotestnet` container registry, and this PR points it to the `celoprod` one.

## Tested

Tested the push on this branch by removing the `main` filter.
