### PR TITLE
Add CELOBRL support.

### DIFF
--- a/src/exchange_adapters/base.ts
+++ b/src/exchange_adapters/base.ts
@@ -146,6 +146,7 @@ export abstract class BaseExchangeAdapter {
     [CeloContract.StableToken, 'CUSD'],
     [ExternalCurrency.USD, 'USD'],
     [ExternalCurrency.EUR, 'EUR'],
+    [ExternalCurrency.BRL, 'BRL'],
     [ExternalCurrency.BTC, 'BTC'],
     [ExternalCurrency.USDT, 'USDT'],
   ])

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,7 @@ export enum ExternalCurrency {
   BTC = 'BTC',
   EUR = 'EUR',
   USDT = 'USDT',
+  BRL = 'BRL',
 }
 
 export type Currency = ExternalCurrency | CeloToken
@@ -43,15 +44,19 @@ export enum OracleCurrencyPair {
   CELOUSD = 'CELOUSD',
   CELOEUR = 'CELOEUR',
   CELOBTC = 'CELOBTC',
+  CELOBRL = 'CELOBRL',
   BTCEUR = 'BTCEUR',
   CELOUSDT = 'CELOUSDT',
   EURUSDT = 'EURUSDT',
   BTCUSD = 'BTCUSD',
+  BTCBRL = 'BTCBRL',
+  USDTBRL = 'USDTBRL',
 }
 
 export const CoreCurrencyPair: OracleCurrencyPair[] = [
   OracleCurrencyPair.CELOEUR,
   OracleCurrencyPair.CELOUSD,
+  OracleCurrencyPair.CELOBRL,
 ]
 
 export const CurrencyPairBaseQuote: Record<
@@ -61,10 +66,13 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.CELOUSD]: { base: CeloContract.GoldToken, quote: ExternalCurrency.USD },
   [OracleCurrencyPair.CELOBTC]: { base: CeloContract.GoldToken, quote: ExternalCurrency.BTC },
   [OracleCurrencyPair.CELOEUR]: { base: CeloContract.GoldToken, quote: ExternalCurrency.EUR },
+  [OracleCurrencyPair.CELOBRL]: { base: CeloContract.GoldToken, quote: ExternalCurrency.BRL },
   [OracleCurrencyPair.BTCEUR]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.EUR },
   [OracleCurrencyPair.CELOUSDT]: { base: CeloContract.GoldToken, quote: ExternalCurrency.USDT },
   [OracleCurrencyPair.EURUSDT]: { base: ExternalCurrency.EUR, quote: ExternalCurrency.USDT },
   [OracleCurrencyPair.BTCUSD]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.USD },
+  [OracleCurrencyPair.BTCBRL]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.BRL },
+  [OracleCurrencyPair.USDTBRL]: { base: ExternalCurrency.USDT, quote: ExternalCurrency.BRL },
 }
 
 export enum AggregationMethod {
@@ -101,6 +109,9 @@ export async function reportTargetForCurrencyPair(
   } else if (pair === OracleCurrencyPair.CELOEUR) {
     // XXX: Workaround until StableTokenEUR makes it fully to ContractKit
     return kit.registry.addressFor('StableTokenEUR' as CeloContract)
+  } else if (pair === OracleCurrencyPair.CELOBRL) {
+    // Workaround until StableTokenBRL makes it fully to ContractKit.
+    return kit.registry.addressFor('StableTokenBRL' as CeloContract)
   } else {
     throw new Error(`${pair} can not be converted to a ReportTarget`)
   }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -58,6 +58,16 @@ describe('utils', () => {
       })
     })
 
+    describe('with CELOBRL', () => {
+      const pair = OracleCurrencyPair.CELOBRL
+      it('looks up the registry', async () => {
+        const addr = Web3.utils.randomHex(20)
+        registryLookup.mockReturnValue(addr)
+        expect(await reportTargetForCurrencyPair(pair, kit)).toEqual(addr)
+        expect(registryLookup).toHaveBeenCalledWith('StableTokenBRL')
+      })
+    })
+
     describe('with CELOBTC', () => {
       const pair = OracleCurrencyPair.CELOBTC
       it('derives the identifier', async () => {


### PR DESCRIPTION
## Description

Adds support for CELOBRL rates reporting, including support for implicit pairs via BTCBRL and USDTBRL pairs.

## Tested

Tested locally by reporting to the `StableTokenEUR` contract.

## Related issues

- Fixes #87 

## Backwards compatibility

As currency pairs were added, and none removed, the oracle remains fully backwards compatible.
