### PR TITLE
Update Coinbase liveness check

### DIFF
--- a/src/exchange_adapters/coinbase.ts
+++ b/src/exchange_adapters/coinbase.ts
@@ -155,8 +155,8 @@ export class CoinbaseAdapter extends BaseExchangeAdapter implements ExchangeAdap
     return (
       res.status === 'online' &&
       res.post_only === false &&
-      // Some stables are in Limit Only and the orderbook is healthy then
-      // res.limit_only === false &&
+      // There used to be a `limit_only` check, but it was removed due to Coinbase using this mode for stablecoin pairs.
+
       res.cancel_only === false &&
       res.trading_disabled === false
     )

--- a/src/exchange_adapters/coinbase.ts
+++ b/src/exchange_adapters/coinbase.ts
@@ -155,7 +155,8 @@ export class CoinbaseAdapter extends BaseExchangeAdapter implements ExchangeAdap
     return (
       res.status === 'online' &&
       res.post_only === false &&
-      res.limit_only === false &&
+      // Some stables are in Limit Only and the orderbook is healthy then
+      // res.limit_only === false &&
       res.cancel_only === false &&
       res.trading_disabled === false
     )

--- a/src/exchange_adapters/coinbase.ts
+++ b/src/exchange_adapters/coinbase.ts
@@ -156,7 +156,6 @@ export class CoinbaseAdapter extends BaseExchangeAdapter implements ExchangeAdap
       res.status === 'online' &&
       res.post_only === false &&
       // There used to be a `limit_only` check, but it was removed due to Coinbase using this mode for stablecoin pairs.
-
       res.cancel_only === false &&
       res.trading_disabled === false
     )

--- a/test/exchange_adapters/coinbase.test.ts
+++ b/test/exchange_adapters/coinbase.test.ts
@@ -205,7 +205,6 @@ describe('CoinbaseAdapter', () => {
   describe('isOrderbookLive', () => {
     const falseStatusIndicators = [
       { post_only: true },
-      { limit_only: true },
       { cancel_only: true },
       { status: 'offline' },
     ]


### PR DESCRIPTION
## Description

Coinbase Exchange has `limit_onlyy=true` flag checked on Coinbase, that means it can't be used for the oracles. After running some risk assessment with Pedro we decided that it was good to remove it as long as other checks are still checked. 

## Other changes

-

## Tested
Updated


## Related issues

-

## Backwards compatibility
-

