### PR TITLE
Handle certificate validation failures.

### DIFF
--- a/src/exchange_adapters/base.ts
+++ b/src/exchange_adapters/base.ts
@@ -391,7 +391,7 @@ export abstract class BaseExchangeAdapter {
               currentCert = issuerCertificate !== currentCert ? issuerCertificate : undefined
             }
           }
-          throw new Error('Pinned fingerprint not found in certificate chain')
+          return Error('Pinned fingerprint not found in certificate chain')
         }
       },
     })


### PR DESCRIPTION
## Description

Previously, the code would raise an exception that would crash the
executable. Now it's handled as a failed checkServerIdentity, and
price sources with failing fetches can be ignored.

From https://nodejs.org/api/tls.html#tlsconnectoptions-callback:
"checkServerIdentity(servername, cert) A callback function to be used (instead of the builtin tls.checkServerIdentity() function) when checking the server's host name (or the provided servername when explicitly set) against the certificate. This should return an Error if verification fails. The method should return undefined if the servername and cert are verified."

## Tested

Tested locally.