### PR TITLE
Fix issues preventing the client from running with non-approved addresses.

### DIFF
--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -419,9 +419,7 @@ export abstract class BaseReporter {
       )
     }
 
-    this.logger.info(
-      `Starting oracle with index #${oracleIndex} ${indexOverrided ? '(mocked)' : ''}`
-    )
+    this.logger.info(`Setting oracle index to ${oracleIndex} ${indexOverrided ? '(mocked)' : ''}`)
 
     this._oracleIndex = oracleIndex
 
@@ -432,7 +430,7 @@ export abstract class BaseReporter {
       : oracleWhitelist.length
 
     this.logger.info(
-      `Found a total of #${this._totalOracleCount} ${oracleCountOverrided ? '(mocked)' : ''}`
+      `Found a total of ${this._totalOracleCount}${oracleCountOverrided ? ' (mocked)' : ''} oracles`
     )
   }
 

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -412,9 +412,9 @@ export abstract class BaseReporter {
       ? this.config.overrideIndex
       : oracleWhitelist.indexOf(normalizeAddressWith0x(this.config.oracleAccount))
 
-    // This should not happen, but handle the edge-case anyway
+    // This could happen if the address hasn't been whitelisted yet.
     if (oracleIndex === -1) {
-      throw Error(
+      this.logger.warn(
         `Account ${this.config.oracleAccount} is not whitelisted as an oracle for ${this.config.currencyPair}`
       )
     }

--- a/test/reporters/base.test.ts
+++ b/test/reporters/base.test.ts
@@ -126,10 +126,8 @@ describe('BaseReporter', () => {
         ]
       })
 
-      it('throws an error', async () => {
-        await expect(async () => createAndInitializeReporter(defaultConfig)).rejects.toThrow(
-          `Account ${mockOracleAccount} is not whitelisted as an oracle for CELOUSD`
-        )
+      it('does not throw an error', async () => {
+        await expect(createAndInitializeReporter(defaultConfig)).resolves.not.toThrow()
       })
     })
 


### PR DESCRIPTION
Instead of letting the client die with an exception when it's not in the list of approved oracles, the behaviour has been changed so that it logs an error message and keeps receiving block headers. The client will attempt to update the approved list every k blocks, where k is the current number of approved oracles.