### PR TITLE
feat: add mercado adapter

### DIFF
--- a/src/data_aggregator.ts
+++ b/src/data_aggregator.ts
@@ -13,6 +13,7 @@ import { OKCoinAdapter } from './exchange_adapters/okcoin'
 import { NovaDaxAdapter } from './exchange_adapters/novadax'
 import { KrakenAdapter } from './exchange_adapters/kraken'
 import { BitstampAdapter } from './exchange_adapters/bitstamp'
+import { MercadoAdapter } from './exchange_adapters/mercado'
 import { MetricCollector } from './metric_collector'
 import { PriceSource, WeightedPrice } from './price_source'
 import {
@@ -54,6 +55,8 @@ function adapterFromExchangeName(name: Exchange, config: ExchangeAdapterConfig):
       return new KrakenAdapter(config)
     case Exchange.BITSTAMP:
       return new BitstampAdapter(config)
+    case Exchange.MERCADO:
+      return new MercadoAdapter(config)
   }
 }
 

--- a/src/exchange_adapters/mercado.ts
+++ b/src/exchange_adapters/mercado.ts
@@ -15,10 +15,10 @@ export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapt
   }
 
   async fetchTicker(): Promise<Ticker> {
-    const [tickerJson,orderbookJson] = await Promise.all([
-      this.fetchFromApi(ExchangeDataType.TICKER,`tickers?symbols=${this.pairSymbol}`),
-      this.fetchFromApi(ExchangeDataType.TICKER,`${this.pairSymbol}/orderbook`),
-    ]) 
+    const [tickerJson, orderbookJson] = await Promise.all([
+      this.fetchFromApi(ExchangeDataType.TICKER, `tickers?symbols=${this.pairSymbol}`),
+      this.fetchFromApi(ExchangeDataType.TICKER, `${this.pairSymbol}/orderbook`),
+    ])
     return this.parseTicker(tickerJson, orderbookJson)
   }
 
@@ -31,39 +31,39 @@ export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapt
   }
 
   /**
-  * 
-  * @param json parsed response from mercado's orderbook endpoint
-  * https://api.mercadobitcoin.net/api/v4/docs#tag/Public-Data/paths/~1{symbol}~1orderbook/get
-  * https://api.mercadobitcoin.net/api/v4/BTC-BRL/orderbook
-  * "asks":[
-  *   ["117275.49879111", "0.0256"],
-  *   ["117532.16627745", "0.01449"],
-  *   ...
-  * ],
-  * "bids":[
-  *    ["117223.32117", "0.00001177"],
-  *    ["117200", "0.00002"],
-  *    .....
-  * ]
-  *
-  * @param json parsed response from mercado's ticker endpoint
-  * https://api.mercadobitcoin.net/api/v4/docs#tag/Public-Data/paths/~1tickers/get
-  * https://api.mercadobitcoin.net/api/v4/tickers?symbols=BTC-BRL
-  * [
-  *  {
-  *  "pair":"BTC-BRL",
-  *  "high":"120700.00000000",
-  *  "low":"117000.00001000",
-  *  "vol":"52.00314436",
-  *  "last":"119548.04744932",
-  *  "buy":"119457.96889001",
-  *  "sell":"119546.04397687",
-  *  "open":"119353.86994450",
-  *  "date":1674561363
-  *  }
-  * ]
-  *
-  */
+   *
+   * @param json parsed response from mercado's orderbook endpoint
+   * https://api.mercadobitcoin.net/api/v4/docs#tag/Public-Data/paths/~1{symbol}~1orderbook/get
+   * https://api.mercadobitcoin.net/api/v4/BTC-BRL/orderbook
+   * "asks":[
+   *   ["117275.49879111", "0.0256"],
+   *   ["117532.16627745", "0.01449"],
+   *   ...
+   * ],
+   * "bids":[
+   *    ["117223.32117", "0.00001177"],
+   *    ["117200", "0.00002"],
+   *    .....
+   * ]
+   *
+   * @param json parsed response from mercado's ticker endpoint
+   * https://api.mercadobitcoin.net/api/v4/docs#tag/Public-Data/paths/~1tickers/get
+   * https://api.mercadobitcoin.net/api/v4/tickers?symbols=BTC-BRL
+   * [
+   *  {
+   *  "pair":"BTC-BRL",
+   *  "high":"120700.00000000",
+   *  "low":"117000.00001000",
+   *  "vol":"52.00314436",
+   *  "last":"119548.04744932",
+   *  "buy":"119457.96889001",
+   *  "sell":"119546.04397687",
+   *  "open":"119353.86994450",
+   *  "date":1674561363
+   *  }
+   * ]
+   *
+   */
   // Using lastPrice to convert from baseVolume to quoteVolume, as Mercado's
   // API does not provide this information. The correct price for the
   // conversion would be the VWAP over the period contemplated by the ticker,
@@ -72,7 +72,7 @@ export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapt
   // was actually on one trade (whereas the buy or sell could have no
   // relation to the VWAP).
 
-  parseTicker(tickerJson: any, orderbookJson:any ): Ticker {
+  parseTicker(tickerJson: any, orderbookJson: any): Ticker {
     const baseVolume = this.safeBigNumberParse(tickerJson[0].vol)!
     const lastPrice = this.safeBigNumberParse(tickerJson[0].last)!
     const quoteVolume = baseVolume?.multipliedBy(lastPrice)
@@ -90,30 +90,30 @@ export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapt
   }
 
   /**
-  * @param json parsed response from mercado's symbols endpoint
-  * Checks status of orderbook
-  * 
-  * https://api.mercadobitcoin.net/api/v4/symbols?symbols=BTC-BRL
-  * https://api.mercadobitcoin.net/api/v4/docs#tag/Public-Data/paths/~1symbols/get
-  * {
-  * "symbol":[ "BTC-BRL" ],
-  * "description":[ "Bitcoin" ],
-  * "currency":[ "BRL" ],
-  * "base-currency":[ "BTC" ],
-  * "exchange-listed":[ true ],
-  * "exchange-traded":[ true ],
-  * "minmovement":[ "1" ],
-  * "pricescale":[ 100000000 ],
-  * "type":[ "CRYPTO" ],
-  * "timezone":[ "America/Sao_Paulo" ],
-  * "session-regular":[ "24x7" ],
-  * "withdrawal-fee":[ "0.0004" ],
-  * "withdraw-minimum":[ "0.001" ],
-  * "deposit-minimum":[ "0.00001" ]
-  * }
-  *
-  * @returns bool
-  */
+   * @param json parsed response from mercado's symbols endpoint
+   * Checks status of orderbook
+   *
+   * https://api.mercadobitcoin.net/api/v4/symbols?symbols=BTC-BRL
+   * https://api.mercadobitcoin.net/api/v4/docs#tag/Public-Data/paths/~1symbols/get
+   * {
+   * "symbol":[ "BTC-BRL" ],
+   * "description":[ "Bitcoin" ],
+   * "currency":[ "BRL" ],
+   * "base-currency":[ "BTC" ],
+   * "exchange-listed":[ true ],
+   * "exchange-traded":[ true ],
+   * "minmovement":[ "1" ],
+   * "pricescale":[ 100000000 ],
+   * "type":[ "CRYPTO" ],
+   * "timezone":[ "America/Sao_Paulo" ],
+   * "session-regular":[ "24x7" ],
+   * "withdrawal-fee":[ "0.0004" ],
+   * "withdraw-minimum":[ "0.001" ],
+   * "deposit-minimum":[ "0.00001" ]
+   * }
+   *
+   * @returns bool
+   */
   async isOrderbookLive(): Promise<boolean> {
     const response = await this.fetchFromApi(
       ExchangeDataType.ORDERBOOK_STATUS,

--- a/src/exchange_adapters/mercado.ts
+++ b/src/exchange_adapters/mercado.ts
@@ -1,6 +1,5 @@
 import { Exchange } from '../utils'
 import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
-
 export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.mercadobitcoin.net/api/v4'
   readonly _exchangeName = Exchange.MERCADO
@@ -16,11 +15,11 @@ export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapt
   }
 
   async fetchTicker(): Promise<Ticker> {
-    const tickerJson = await this.fetchFromApi(
-      ExchangeDataType.TICKER,
-      `tickers?symbols=${this.pairSymbol}`
-    )
-    return this.parseTicker(tickerJson)
+    const [tickerJson,orderbookJson] = await Promise.all([
+      this.fetchFromApi(ExchangeDataType.TICKER,`tickers?symbols=${this.pairSymbol}`),
+      this.fetchFromApi(ExchangeDataType.TICKER,`${this.pairSymbol}/orderbook`),
+    ]) 
+    return this.parseTicker(tickerJson, orderbookJson)
   }
 
   async fetchTrades(): Promise<Trade[]> {
@@ -32,74 +31,89 @@ export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapt
   }
 
   /**
-   *
-   * @param json parsed response from mercado's ticker endpoint
-   * https://api.mercadobitcoin.net/api/v4/docs#tag/Public-Data/paths/~1tickers/get
-   * https://api.mercadobitcoin.net/api/v4/tickers?symbols=BTC-BRL
-   * [
-   *  {
-   *  "pair":"BTC-BRL",
-   *  "high":"120700.00000000",
-   *  "low":"117000.00001000",
-   *  "vol":"52.00314436",
-   *  "last":"119548.04744932",
-   *  "buy":"119457.96889001",
-   *  "sell":"119546.04397687",
-   *  "open":"119353.86994450",
-   *  "date":1674561363
-   *  }
-   * ]
-   *
-   */
+  * 
+  * @param json parsed response from mercado's orderbook endpoint
+  * https://api.mercadobitcoin.net/api/v4/docs#tag/Public-Data/paths/~1{symbol}~1orderbook/get
+  * https://api.mercadobitcoin.net/api/v4/BTC-BRL/orderbook
+  * "asks":[
+  *   ["117275.49879111", "0.0256"],
+  *   ["117532.16627745", "0.01449"],
+  *   ...
+  * ],
+  * "bids":[
+  *    ["117223.32117", "0.00001177"],
+  *    ["117200", "0.00002"],
+  *    .....
+  * ]
+  *
+  * @param json parsed response from mercado's ticker endpoint
+  * https://api.mercadobitcoin.net/api/v4/docs#tag/Public-Data/paths/~1tickers/get
+  * https://api.mercadobitcoin.net/api/v4/tickers?symbols=BTC-BRL
+  * [
+  *  {
+  *  "pair":"BTC-BRL",
+  *  "high":"120700.00000000",
+  *  "low":"117000.00001000",
+  *  "vol":"52.00314436",
+  *  "last":"119548.04744932",
+  *  "buy":"119457.96889001",
+  *  "sell":"119546.04397687",
+  *  "open":"119353.86994450",
+  *  "date":1674561363
+  *  }
+  * ]
+  *
+  */
   // Using lastPrice to convert from baseVolume to quoteVolume, as Mercado's
   // API does not provide this information. The correct price for the
   // conversion would be the VWAP over the period contemplated by the ticker,
   // but it's also not available. As a price has to be chosen for the
   // conversion, and none of them are correct, lastPrice is chose as it
   // was actually on one trade (whereas the buy or sell could have no
-  // relation to the VWAP). Similar argumentation for ask and bid.
+  // relation to the VWAP).
 
-  parseTicker(json: any): Ticker {
-    const baseVolume = this.safeBigNumberParse(json[0].vol)!
-    const lastPrice = this.safeBigNumberParse(json[0].last)!
+  parseTicker(tickerJson: any, orderbookJson:any ): Ticker {
+    const baseVolume = this.safeBigNumberParse(tickerJson[0].vol)!
+    const lastPrice = this.safeBigNumberParse(tickerJson[0].last)!
     const quoteVolume = baseVolume?.multipliedBy(lastPrice)
     const ticker = {
       ...this.priceObjectMetadata,
-      ask: this.safeBigNumberParse(json[0].sell)!,
+      ask: this.safeBigNumberParse(orderbookJson.asks[0][0])!,
       baseVolume,
-      bid: this.safeBigNumberParse(json[0].buy)!,
+      bid: this.safeBigNumberParse(orderbookJson.bids[0][0])!,
       lastPrice,
       quoteVolume,
-      timestamp: this.safeBigNumberParse(json[0].date)?.toNumber()!,
+      timestamp: this.safeBigNumberParse(tickerJson[0].date)?.toNumber()!,
     }
     this.verifyTicker(ticker)
     return ticker
   }
 
   /**
-   * @param json parsed response from mercado's symbols endpoint
-   * Checks status of orderbook
-   * https://api.mercadobitcoin.net/api/v4/symbols?symbols=BTC-BRL
-   *
-   * {
-   * "symbol":[ "BTC-BRL" ],
-   * "description":[ "Bitcoin" ],
-   * "currency":[ "BRL" ],
-   * "base-currency":[ "BTC" ],
-   * "exchange-listed":[ true ],
-   * "exchange-traded":[ true ],
-   * "minmovement":[ "1" ],
-   * "pricescale":[ 100000000 ],
-   * "type":[ "CRYPTO" ],
-   * "timezone":[ "America/Sao_Paulo" ],
-   * "session-regular":[ "24x7" ],
-   * "withdrawal-fee":[ "0.0004" ],
-   * "withdraw-minimum":[ "0.001" ],
-   * "deposit-minimum":[ "0.00001" ]
-   * }
-   *
-   * @returns bool
-   */
+  * @param json parsed response from mercado's symbols endpoint
+  * Checks status of orderbook
+  * 
+  * https://api.mercadobitcoin.net/api/v4/symbols?symbols=BTC-BRL
+  * https://api.mercadobitcoin.net/api/v4/docs#tag/Public-Data/paths/~1symbols/get
+  * {
+  * "symbol":[ "BTC-BRL" ],
+  * "description":[ "Bitcoin" ],
+  * "currency":[ "BRL" ],
+  * "base-currency":[ "BTC" ],
+  * "exchange-listed":[ true ],
+  * "exchange-traded":[ true ],
+  * "minmovement":[ "1" ],
+  * "pricescale":[ 100000000 ],
+  * "type":[ "CRYPTO" ],
+  * "timezone":[ "America/Sao_Paulo" ],
+  * "session-regular":[ "24x7" ],
+  * "withdrawal-fee":[ "0.0004" ],
+  * "withdraw-minimum":[ "0.001" ],
+  * "deposit-minimum":[ "0.00001" ]
+  * }
+  *
+  * @returns bool
+  */
   async isOrderbookLive(): Promise<boolean> {
     const response = await this.fetchFromApi(
       ExchangeDataType.ORDERBOOK_STATUS,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,6 +33,7 @@ export enum Exchange {
   GEMINI = 'GEMINI',
   KRAKEN = 'KRAKEN',
   BITSTAMP = 'BITSTAMP',
+  MERCADO = 'MERCADO',
 }
 
 export enum ExternalCurrency {

--- a/test/exchange_adapters/mercado.test.ts
+++ b/test/exchange_adapters/mercado.test.ts
@@ -35,18 +35,18 @@ describe(' adapter', () => {
       date: 1674561363,
     },
   ]
-  
+
   const validOrderbookJson = {
-    "asks":[
-       ["117275.49879111", "0.0256"],
-       ["117532.16627745", "0.01449"],
+    asks: [
+      ['117275.49879111', '0.0256'],
+      ['117532.16627745', '0.01449'],
     ],
-    "bids":[
-       ["117223.32117", "0.00001177"],
-       ["117200", "0.00002"],
-    ]
- }
-  
+    bids: [
+      ['117223.32117', '0.00001177'],
+      ['117200', '0.00002'],
+    ],
+  }
+
   const inValidMockTickerJson = [
     {
       pair: 'BTC-BRL',
@@ -61,16 +61,10 @@ describe(' adapter', () => {
     },
   ]
 
-  const inValidOrderbookJson ={
-    "asks":[
-       [],
-       ["117532.16627745", "0.01449"],
-    ],
-    "bids":[
-       [],
-       ["117200", "0.00002"],
-    ]
- }
+  const inValidOrderbookJson = {
+    asks: [[], ['117532.16627745', '0.01449']],
+    bids: [[], ['117200', '0.00002']],
+  }
 
   describe('parseTicker', () => {
     it('handles a response that matches the documentation', () => {

--- a/test/exchange_adapters/mercado.test.ts
+++ b/test/exchange_adapters/mercado.test.ts
@@ -35,7 +35,18 @@ describe(' adapter', () => {
       date: 1674561363,
     },
   ]
-
+  
+  const validOrderbookJson = {
+    "asks":[
+       ["117275.49879111", "0.0256"],
+       ["117532.16627745", "0.01449"],
+    ],
+    "bids":[
+       ["117223.32117", "0.00001177"],
+       ["117200", "0.00002"],
+    ]
+ }
+  
   const inValidMockTickerJson = [
     {
       pair: 'BTC-BRL',
@@ -50,15 +61,26 @@ describe(' adapter', () => {
     },
   ]
 
+  const inValidOrderbookJson ={
+    "asks":[
+       [],
+       ["117532.16627745", "0.01449"],
+    ],
+    "bids":[
+       [],
+       ["117200", "0.00002"],
+    ]
+ }
+
   describe('parseTicker', () => {
     it('handles a response that matches the documentation', () => {
-      const ticker = mercadoAdapter.parseTicker(validMockTickerJson)
+      const ticker = mercadoAdapter.parseTicker(validMockTickerJson, validOrderbookJson)
       expect(ticker).toEqual({
         source: Exchange.MERCADO,
         symbol: mercadoAdapter.standardPairSymbol,
-        ask: new BigNumber(119546.04397687),
+        ask: new BigNumber(117275.49879111),
         baseVolume: new BigNumber(52.00314436),
-        bid: new BigNumber(119457.96889001),
+        bid: new BigNumber(117223.32117),
         lastPrice: new BigNumber(119548.04744932),
         quoteVolume: new BigNumber(52.00314436).multipliedBy(new BigNumber(119548.04744932)),
         timestamp: 1674561363,
@@ -67,7 +89,7 @@ describe(' adapter', () => {
 
     it('throws an error when a json field mapped to a required ticker field is missing or empty', () => {
       expect(() => {
-        mercadoAdapter.parseTicker(inValidMockTickerJson)
+        mercadoAdapter.parseTicker(inValidMockTickerJson, inValidOrderbookJson)
       }).toThrowError('bid, ask, lastPrice, baseVolume not defined')
     })
   })

--- a/test/exchange_adapters/mercado.test.ts
+++ b/test/exchange_adapters/mercado.test.ts
@@ -1,0 +1,128 @@
+import { MercadoAdapter } from '../../src/exchange_adapters/mercado'
+import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
+import { baseLogger } from '../../src/default_config'
+import { Exchange, ExternalCurrency } from '../../src/utils'
+import BigNumber from 'bignumber.js'
+
+describe(' adapter', () => {
+  let mercadoAdapter: MercadoAdapter
+
+  const config: ExchangeAdapterConfig = {
+    baseCurrency: ExternalCurrency.USDC,
+    baseLogger,
+    quoteCurrency: ExternalCurrency.USD,
+  }
+
+  beforeEach(() => {
+    mercadoAdapter = new MercadoAdapter(config)
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.clearAllMocks()
+  })
+
+  const validMockTickerJson = [
+    {
+      pair: 'BTC-BRL',
+      high: '120700.00000000',
+      low: '117000.00001000',
+      vol: '52.00314436',
+      last: '119548.04744932',
+      buy: '119457.96889001',
+      sell: '119546.04397687',
+      open: '119353.86994450',
+      date: 1674561363,
+    },
+  ]
+
+  const inValidMockTickerJson = [
+    {
+      pair: 'BTC-BRL',
+      high: '120700.00000000',
+      low: '117000.00001000',
+      vol: undefined,
+      last: undefined,
+      buy: '',
+      sell: '',
+      open: '119353.86994450',
+      date: undefined,
+    },
+  ]
+
+  describe('parseTicker', () => {
+    it('handles a response that matches the documentation', () => {
+      const ticker = mercadoAdapter.parseTicker(validMockTickerJson)
+      expect(ticker).toEqual({
+        source: Exchange.MERCADO,
+        symbol: mercadoAdapter.standardPairSymbol,
+        ask: new BigNumber(119546.04397687),
+        baseVolume: new BigNumber(52.00314436),
+        bid: new BigNumber(119457.96889001),
+        lastPrice: new BigNumber(119548.04744932),
+        quoteVolume: new BigNumber(52.00314436).multipliedBy(new BigNumber(119548.04744932)),
+        timestamp: 1674561363,
+      })
+    })
+
+    it('throws an error when a json field mapped to a required ticker field is missing or empty', () => {
+      expect(() => {
+        mercadoAdapter.parseTicker(inValidMockTickerJson)
+      }).toThrowError('bid, ask, lastPrice, baseVolume not defined')
+    })
+  })
+
+  describe('fetchTrades', () => {
+    it('returns empty array', async () => {
+      expect(await mercadoAdapter.fetchTrades()).toEqual([])
+    })
+  })
+
+  const mockStatusJson = {
+    symbol: ['BTC-BRL'],
+    description: ['Bitcoin'],
+    currency: ['BRL'],
+    'base-currency': ['BTC'],
+    'exchange-listed': [true],
+    'exchange-traded': [true],
+    minmovement: ['1'],
+    pricescale: [100000000],
+    type: ['CRYPTO'],
+    timezone: ['America/Sao_Paulo'],
+    'session-regular': ['24x7'],
+    'withdrawal-fee': ['0.0004'],
+    'withdraw-minimum': ['0.001'],
+    'deposit-minimum': ['0.00001'],
+  }
+
+  const mockWrongStatusJson = {
+    symbol: ['BTC-BRL'],
+    description: ['Bitcoin'],
+    currency: ['BRL'],
+    'base-currency': ['BTC'],
+    'exchange-listed': [true],
+    'exchange-traded': [false],
+    minmovement: ['1'],
+    pricescale: [100000000],
+    type: ['CRYPTO'],
+    timezone: ['America/Sao_Paulo'],
+    'session-regular': ['24x7'],
+    'withdrawal-fee': ['0.0004'],
+    'withdraw-minimum': ['0.001'],
+    'deposit-minimum': ['0.00001'],
+  }
+
+  describe('isOrderbookLive', () => {
+    it('returns true', async () => {
+      jest.spyOn(mercadoAdapter, 'fetchFromApi').mockReturnValue(Promise.resolve(mockStatusJson))
+      expect(await mercadoAdapter.isOrderbookLive()).toEqual(true)
+    })
+
+    it('returns false when Orderbook is not live', async () => {
+      jest
+        .spyOn(mercadoAdapter, 'fetchFromApi')
+        .mockReturnValue(Promise.resolve(mockWrongStatusJson))
+      expect(await mercadoAdapter.isOrderbookLive()).toEqual(false)
+    })
+  })
+})


### PR DESCRIPTION
## Description

added the mercadoBitcoin adapter 
Please take look at the parseTicker() function. The response is a bit different from other APIs therefore I had to use some other fields to build the Ticker object.  I left a comment explaining which and why I used those fields. 

## Other changes

N/A

## Tested

- tested each of the functions in the adapter
- ran oracle locally

## Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/124

## Backwards compatibility
