### PR TITLE
feat: add missing USDC and USDT currency pairs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,12 +62,14 @@ export enum OracleCurrencyPair {
   BTCUSD = 'BTCUSD',
   BTCBRL = 'BTCBRL',
   USDTUSD = 'USDTUSD',
+  USDTUSDC = 'USDTUSDC',
   USDTEUR = 'USDTEUR',
   USDTBRL = 'USDTBRL',
   BUSDBRL = 'BUSDBRL',
   BUSDUSD = 'BUSDUSD',
   USDBRL = 'USDBRL',
   USDCUSD = 'USDCUSD',
+  USDCUSDT = 'USDCUSDT',
 }
 
 export const CoreCurrencyPair: OracleCurrencyPair[] = [
@@ -89,6 +91,7 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.CELOBUSD]: { base: CeloContract.GoldToken, quote: ExternalCurrency.BUSD },
   [OracleCurrencyPair.EURUSDT]: { base: ExternalCurrency.EUR, quote: ExternalCurrency.USDT },
   [OracleCurrencyPair.USDTUSD]: { base: ExternalCurrency.USDT, quote: ExternalCurrency.USD },
+  [OracleCurrencyPair.USDTUSDC]: { base: ExternalCurrency.USDT, quote: ExternalCurrency.USDC },
   [OracleCurrencyPair.USDTEUR]: { base: ExternalCurrency.USDT, quote: ExternalCurrency.EUR },
   [OracleCurrencyPair.BTCUSD]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.USD },
   [OracleCurrencyPair.BTCBRL]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.BRL },
@@ -97,6 +100,7 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.BUSDUSD]: { base: ExternalCurrency.BUSD, quote: ExternalCurrency.USD },
   [OracleCurrencyPair.USDBRL]: { base: ExternalCurrency.USD, quote: ExternalCurrency.BRL },
   [OracleCurrencyPair.USDCUSD]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.USD },
+  [OracleCurrencyPair.USDCUSDT]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.USDT },
 }
 
 export enum AggregationMethod {


### PR DESCRIPTION
## Description

We got an error while trying to deploy the new `USDCUSD` oracle config to alfajores and after investigating realized that it's because `USDCUSDT` and `USDTUSDC` were not defined as pairs in the client code.

## Tested

Ran it locally with the latest config in https://github.com/celo-org/celo-monorepo/blob/master/packages/helm-charts/oracle/USDCUSD.yaml#L22-L27 and removing WhiteBit (this adapter has not been added yet, but lets do that in a different issue)
