### PR TITLE
Oracle official v1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ For a friendlier developer experience, the bunayn CLI can be used to output pret
 yarn start | npx bunyan
 ```
 
+## Deployment
+
+Docker images are pushed to a public container [registry](https://console.cloud.google.com/artifacts/docker/celo-testnet-production/us-west1/celo-oracle/celo-oracle) upon every release. The latest price sources and data aggregation parameters can be found as helm charts in the celo [monorepo](https://github.com/celo-org/celo-monorepo/tree/master/packages/helm-charts/oracle).
+
+The recommended configuration at the moment is [75c223a](https://github.com/celo-org/celo-monorepo/tree/75c223a1b5296ac0fecdb54fb29c52432cf3fece/packages/helm-charts/oracle).
+
+
 ## Component Overview
 
 <!-- TODO: Add architecture diagram here -->

--- a/build_and_publish.sh
+++ b/build_and_publish.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail
 
 REPOSITORY="us-west1-docker.pkg.dev/celo-testnet-production/celo-oracle"
 
@@ -9,8 +8,13 @@ COMMIT_HASH=$(git log -1 --pretty=%h)
 
 VERSION="$PACKAGE_NAME-$PACKAGE_VERSION"
 
-gcloud artifacts docker tags list $REPOSITORY | grep $PACKAGE_VERSION > /dev/null 2>&1
-PACKAGE_VERSION_EXISTS=`expr $? = 0` # if grep finds something exit code 0 otherwise 1
+gcloud artifacts docker tags list $REPOSITORY | grep -w $PACKAGE_VERSION > /dev/null 2>&1
+# if grep finds something exit code 0 otherwise 1
+if [[ $? -eq 0 ]]; then
+  PACKAGE_VERSION_EXISTS=1
+else
+  PACKAGE_VERSION_EXISTS=0
+fi
 
 if [[ $BUILD_ENV != "production" && $BUILD_ENV != "staging" ]]; then
   echo "Invalid BUILD_ENV: $BUILD_ENV"

--- a/build_and_publish.sh
+++ b/build_and_publish.sh
@@ -8,28 +8,26 @@ COMMIT_HASH=$(git log -1 --pretty=%h)
 
 VERSION="$PACKAGE_NAME-$PACKAGE_VERSION"
 
-gcloud artifacts docker tags list $REPOSITORY | grep -w $PACKAGE_VERSION > /dev/null 2>&1
-# if grep finds something exit code 0 otherwise 1
-if [[ $? -eq 0 ]]; then
-  PACKAGE_VERSION_EXISTS=1
-else
-  PACKAGE_VERSION_EXISTS=0
-fi
-
-if [[ $BUILD_ENV != "production" && $BUILD_ENV != "staging" ]]; then
-  echo "Invalid BUILD_ENV: $BUILD_ENV"
-  exit 1;
-fi
+# Check if the package version already exists in the repository
+# 2>&1 is used to redirect stderr to stdout so that grep can 
+# search in the full output of the gcloud command
+gcloud artifacts docker tags list $REPOSITORY --filter "tag~$PACKAGE_VERSION\$" 2>&1 | grep "Listed 0 items" > /dev/null
+# if grep finds "Listed 0 items" exit code is 0 which means that the package version does not exist
+PACKAGE_VERSION_EXISTS=$?
 
 if [[ $PACKAGE_VERSION_EXISTS -eq 1 && $BUILD_ENV == "production" ]]; then
   echo "Package version already exists and build env is production."
   echo "In order to build a production image you should bump the package version."
-  exit 1;
+  exit 1
+fi
+
+if [[ $BUILD_ENV != "production" && $BUILD_ENV != "staging" ]]; then
+  echo "Invalid BUILD_ENV: $BUILD_ENV"
+  exit 1
 fi
 
 echo "Building version $VERSION"
 docker buildx build --platform linux/amd64 -t $PACKAGE_NAME .
-
 
 echo "Tagging and pushing"
 docker tag $PACKAGE_NAME $REPOSITORY/$PACKAGE_NAME:$COMMIT_HASH
@@ -42,7 +40,3 @@ else
   docker tag $PACKAGE_NAME $REPOSITORY/$PACKAGE_NAME:latest
   docker push $REPOSITORY/$PACKAGE_NAME:latest
 fi
-
-# Pushing requires a one time set-up: 
-# gcloud auth configure-docker \
-#    us-west1-docker.pkg.dev

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "celo-oracle",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Oracle application to aggregate and report exchange rates to the Celo network",
   "author": "Celo",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "celo-oracle",
-  "version": "1.0.0-rc5",
+  "version": "1.0.1",
   "description": "Oracle application to aggregate and report exchange rates to the Celo network",
   "author": "Celo",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

This updates the version in the package.json to `1.0.0` to make it the first official oracle client release 🎉 From now on we will follow a more semantic versioning release process adding github releases and changelog notes.

## Other changes

* Updated the `build_and_publish.sh` script to use the `-w` grep parameter to not treat the version as a regex. Otherwise it would find a match even though the version didn't really existed and failed to push the image. Also made some other small changes for better readability.

* Added a `deployment` section in the readme to link to the latest recommended config that oracle providers can refer to.

## Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/157
