### PR TITLE
chore: add USDCEUR config

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,7 +70,9 @@ export enum OracleCurrencyPair {
   BUSDUSD = 'BUSDUSD',
   USDBRL = 'USDBRL',
   USDCUSD = 'USDCUSD',
+  USDCEUR = 'USDCEUR',
   USDCUSDT = 'USDCUSDT',
+  EURUSD = 'EURUSD',
 }
 
 export const CoreCurrencyPair: OracleCurrencyPair[] = [
@@ -101,7 +103,9 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.BUSDUSD]: { base: ExternalCurrency.BUSD, quote: ExternalCurrency.USD },
   [OracleCurrencyPair.USDBRL]: { base: ExternalCurrency.USD, quote: ExternalCurrency.BRL },
   [OracleCurrencyPair.USDCUSD]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.USD },
+  [OracleCurrencyPair.USDCEUR]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.EUR },
   [OracleCurrencyPair.USDCUSDT]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.USDT },
+  [OracleCurrencyPair.EURUSD]: { base: ExternalCurrency.EUR, quote: ExternalCurrency.USD },
 }
 
 export enum AggregationMethod {


### PR DESCRIPTION
## Description
Add USDCEUR configs

## Other changes

No

## Tested

Ran the client locally with USDCEUR rates: 
```
[
  [
  {exchange: 'KRAKEN', symbol: 'USDCEUR', toInvert: false}
  ],
  [
  {exchange: 'COINBASE', symbol: 'USDTUSDC', toInvert: true},
  {exchange: 'COINBASE', symbol: 'USDTEUR', toInvert: false}
  ],
  [
  {exchange: 'WHITEBIT', symbol: 'USDCUSDT', toInvert: false},
  {exchange: 'COINBASE', symbol: 'USDTEUR', toInvert: false}
  ],
  [
  {exchange: 'KRAKEN', symbol: 'USDCUSD', toInvert: false},
  {exchange: 'KRAKEN', symbol: 'EURUSD', toInvert: true}
  ],
]
```
## Related issues

- Fixes part of https://github.com/mento-protocol/mento-general/issues/164

## Backwards compatibility

fully
