### PR TITLE
Feature/fix oracle config

### DIFF
--- a/src/exchange_adapters/novadax.ts
+++ b/src/exchange_adapters/novadax.ts
@@ -6,7 +6,7 @@ export class NovaDaxAdapter extends BaseExchangeAdapter implements ExchangeAdapt
   readonly _exchangeName = Exchange.NOVADAX
   // NovaDAX's certificate fingerprint.
   readonly _certFingerprint256 =
-    '4F:04:74:C6:3E:28:50:64:B1:38:00:09:8A:79:6F:FF:BF:C0:E8:AB:98:AD:AE:99:88:FD:66:3A:5A:48:00:24'
+    'A2:05:26:4C:3F:90:D3:DB:37:4A:CE:4E:AF:33:8B:51:89:75:39:2D:7A:98:2F:EE:76:B8:2F:4A:02:23:89:7B'
 
   private static readonly tokenSymbolMap = NovaDaxAdapter.standardTokenSymbolMap
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,6 +61,7 @@ export enum OracleCurrencyPair {
   CELOBUSD = 'CELOBUSD',
   EURUSDT = 'EURUSDT',
   BTCUSD = 'BTCUSD',
+  BTCUSDT = 'BTCUSDT',
   BTCBRL = 'BTCBRL',
   USDTUSD = 'USDTUSD',
   USDTUSDC = 'USDTUSDC',
@@ -106,6 +107,7 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.USDCEUR]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.EUR },
   [OracleCurrencyPair.USDCUSDT]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.USDT },
   [OracleCurrencyPair.EURUSD]: { base: ExternalCurrency.EUR, quote: ExternalCurrency.USD },
+  [OracleCurrencyPair.BTCUSDT]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.USDT },
 }
 
 export enum AggregationMethod {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,7 +70,9 @@ export enum OracleCurrencyPair {
   BUSDUSD = 'BUSDUSD',
   USDBRL = 'USDBRL',
   USDCUSD = 'USDCUSD',
+  USDCEUR = 'USDCEUR',
   USDCUSDT = 'USDCUSDT',
+  EURUSD = 'EURUSD',
 }
 
 export const CoreCurrencyPair: OracleCurrencyPair[] = [
@@ -101,7 +103,9 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.BUSDUSD]: { base: ExternalCurrency.BUSD, quote: ExternalCurrency.USD },
   [OracleCurrencyPair.USDBRL]: { base: ExternalCurrency.USD, quote: ExternalCurrency.BRL },
   [OracleCurrencyPair.USDCUSD]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.USD },
+  [OracleCurrencyPair.USDCEUR]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.EUR },
   [OracleCurrencyPair.USDCUSDT]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.USDT },
+  [OracleCurrencyPair.EURUSD]: { base: ExternalCurrency.EUR, quote: ExternalCurrency.USD },
 }
 
 export enum AggregationMethod {


### PR DESCRIPTION
## Description

Add BTCUSDT oracle pair config that was breaking the client. It is also including the EUR config from this PR https://github.com/celo-org/celo-oracle/pull/153

## Other changes

- updated Novadax exchange adapter certificate

## Tested

ran the config and novadax API call locally

## Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/169

## Backwards compatibility

yup
