### PR TITLE
fix: reduce gasPriceMultiplier

### DIFF
--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -41,7 +41,7 @@ export const defaultBaseReporterConfig: BaseReporterConfigSubset = {
   circuitBreakerPriceChangeThresholdMin: new BigNumber(0.15), // 15%
   circuitBreakerPriceChangeThresholdTimeMultiplier: new BigNumber(0.0075),
   circuitBreakerDurationTimeMs: 20 * 60 * 1000, // 20 minutes.
-  gasPriceMultiplier: new BigNumber(5),
+  gasPriceMultiplier: new BigNumber(2),
   transactionRetryLimit: 3,
   transactionRetryGasPriceMultiplier: new BigNumber(0.1),
   unusedOracleAddresses: [],

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -41,7 +41,7 @@ export const defaultBaseReporterConfig: BaseReporterConfigSubset = {
   circuitBreakerPriceChangeThresholdMin: new BigNumber(0.15), // 15%
   circuitBreakerPriceChangeThresholdTimeMultiplier: new BigNumber(0.0075),
   circuitBreakerDurationTimeMs: 20 * 60 * 1000, // 20 minutes.
-  gasPriceMultiplier: new BigNumber(2),
+  gasPriceMultiplier: new BigNumber(1.5),
   transactionRetryLimit: 3,
   transactionRetryGasPriceMultiplier: new BigNumber(0.1),
   unusedOracleAddresses: [],


### PR DESCRIPTION
## Description

This reduces the default `gasPriceMultiplier` value from `5` to `2` as we increased it a long time ago during high network usage but we don't really have a reason for it being that high right now, so the clients are unnecessarily overpaying when sending reports.

## Tested

Ran it locally and printed the configuration to check it was updated

## Related issues

-  This PR together with https://github.com/celo-org/celo-monorepo/pull/10182/ fixes https://github.com/mento-protocol/mento-general/issues/165

## Backwards compatibility

- Yes