### PR TITLE
[Feature] Add new metric for the max percentage deviation (Max price cross-sectional deviation) to improve monitoring and alerting

### DIFF
--- a/src/aggregator_functions.ts
+++ b/src/aggregator_functions.ts
@@ -114,6 +114,7 @@ export function crossCheckPriceData(
   // 1. Prices should not deviate more than maxPercentageDeviation.
   const prices = tickerData.map((price: WeightedPrice) => price.price)
   const maxNormalizedAbsMeanDev = maxPercentageDeviaton(prices)
+  config.metricCollector?.maxPercentageDeviation(config.currencyPair, maxNormalizedAbsMeanDev)
   assert(
     maxNormalizedAbsMeanDev.isLessThanOrEqualTo(config.maxPercentageDeviation),
     `Max price cross-sectional deviation too large (${maxNormalizedAbsMeanDev} >= ${config.maxPercentageDeviation} )`

--- a/src/metric_collector.ts
+++ b/src/metric_collector.ts
@@ -67,6 +67,7 @@ export class MetricCollector {
 
   private tickerPropertyGauge: Gauge<string>
   private priceSourceGauge: Gauge<string>
+  private maxPercentageDeviationGauge: Gauge<string>
 
   private transactionBlockNumberGauge: Gauge<string>
   private transactionGasGauge: Gauge<string>
@@ -156,6 +157,12 @@ export class MetricCollector {
       name: 'oracle_price_source',
       help: 'Gauge indicating values from different price sources',
       labelNames: ['pair', 'source', 'property'],
+    })
+
+    this.maxPercentageDeviationGauge = new Gauge({
+      name: 'oracle_max_percentage_deviation',
+      help: 'Gauge to indicate the max price cross-sectional deviation of a price pair',
+      labelNames: ['currencyPair'],
     })
 
     this.transactionBlockNumberGauge = new Gauge({
@@ -329,6 +336,13 @@ export class MetricCollector {
   priceSource(pair: string, source: string, weightedPrice: WeightedPrice) {
     this.priceSourceGauge.set({ pair, source, property: 'price' }, weightedPrice.price.toNumber())
     this.priceSourceGauge.set({ pair, source, property: 'weight' }, weightedPrice.weight.toNumber())
+  }
+
+  /**
+   * Indicates the max price cross-sectional deviation of a price pair
+   */
+  maxPercentageDeviation(pair: string, maxPercentageDeviation: BigNumber) {
+    this.maxPercentageDeviationGauge.set({ pair }, maxPercentageDeviation.toNumber())
   }
 
   /**


### PR DESCRIPTION
## Description

Adds a new metric for the max percentage deviation (Max price cross-sectional deviation) to improve monitoring and alerting.
See #174 for more information.

## Tested

⚠️ Changes are not tested yet. It's a simple change, so nothing should break, but i'll test it anyway.

## Related issues

- Fixes #174

## Backwards compatibility

Backward compatible since there is only a new metric being added
