### PR TITLE
feat: add Bitmart adapter

### DIFF
--- a/src/data_aggregator.ts
+++ b/src/data_aggregator.ts
@@ -18,6 +18,9 @@ import { BitstampAdapter } from './exchange_adapters/bitstamp'
 import { MercadoAdapter } from './exchange_adapters/mercado'
 import { BitgetAdapter } from './exchange_adapters/bitget'
 import { MetricCollector } from './metric_collector'
+import { GeminiAdapter } from './exchange_adapters/gemini'
+import { WhitebitAdapter } from './exchange_adapters/whitebit'
+import { BitMartAdapter } from './exchange_adapters/bitmart'
 import { PriceSource, WeightedPrice } from './price_source'
 import {
   ExchangePriceSourceConfig,
@@ -34,8 +37,6 @@ import {
   PromiseStatus,
   SettledPromise,
 } from './utils'
-import { GeminiAdapter } from './exchange_adapters/gemini'
-import { WhitebitAdapter } from './exchange_adapters/whitebit'
 
 function adapterFromExchangeName(name: Exchange, config: ExchangeAdapterConfig): ExchangeAdapter {
   switch (name) {
@@ -69,6 +70,8 @@ function adapterFromExchangeName(name: Exchange, config: ExchangeAdapterConfig):
       return new WhitebitAdapter(config)
     case Exchange.BITGET:
       return new BitgetAdapter(config)
+    case Exchange.BITMART:
+      return new BitMartAdapter(config)
   }
 }
 

--- a/src/exchange_adapters/base.ts
+++ b/src/exchange_adapters/base.ts
@@ -152,7 +152,6 @@ export abstract class BaseExchangeAdapter {
     [ExternalCurrency.BUSD, 'BUSD'],
     [ExternalCurrency.USDC, 'USDC'],
     [ExternalCurrency.EUROC, 'EUROC'],
-    [ExternalCurrency.XOF, 'XOF'],
   ])
 
   protected readonly logger: Logger

--- a/src/exchange_adapters/base.ts
+++ b/src/exchange_adapters/base.ts
@@ -151,6 +151,8 @@ export abstract class BaseExchangeAdapter {
     [ExternalCurrency.USDT, 'USDT'],
     [ExternalCurrency.BUSD, 'BUSD'],
     [ExternalCurrency.USDC, 'USDC'],
+    [ExternalCurrency.EUROC, 'EUROC'],
+    [ExternalCurrency.XOF, 'XOF'],
   ])
 
   protected readonly logger: Logger

--- a/src/exchange_adapters/bitmart.ts
+++ b/src/exchange_adapters/bitmart.ts
@@ -1,0 +1,111 @@
+import { Exchange } from '../utils'
+import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
+
+export class BitMartAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
+  baseApiUrl = 'https://api-cloud.bitmart.com'
+  readonly _exchangeName = Exchange.BITMART
+  readonly _certFingerprint256 =
+    '9D:44:FC:FB:7F:D3:14:1E:3C:E7:DB:B1:BF:E2:60:6A:D2:96:C6:7C:10:C5:A9:1F:58:D3:58:C0:19:82:85:5A'
+  private static readonly tokenSymbolMap = BitMartAdapter.standardTokenSymbolMap
+
+  protected generatePairSymbol(): string {
+    return `${BitMartAdapter.tokenSymbolMap.get(
+      this.config.baseCurrency
+    )}_${BitMartAdapter.tokenSymbolMap.get(this.config.quoteCurrency)}`
+  }
+
+  async fetchTicker(): Promise<Ticker> {
+    const tickerJson = await this.fetchFromApi(
+      ExchangeDataType.TICKER,
+      `spot/v1/ticker_detail?symbol=${this.pairSymbol}`
+    )
+    return this.parseTicker(tickerJson)
+  }
+
+  async fetchTrades(): Promise<Trade[]> {
+    // Trade data is not needed by oracle but is required by the parent class.
+    // This function along with all other functions that are not needed by the oracle will
+    // be removed in a future PR.
+    // -- @bayological ;) --
+    return []
+  }
+
+  /**
+   *
+   * @param json parsed response from bitmart's ticker endpoint
+   * {
+   * "message":"OK",
+   * "code":1000,
+   * "trace":"0f0e93db0eaf472886fbac3dc691c22f.59.16892370225147127",
+   * "data":{
+   *    "symbol":"EUROC_USDC",
+   *    "last_price":"1.10774487",
+   *    "quote_volume_24h":"91116.51006870",
+   *    "base_volume_24h":"82563.0",
+   *    "high_24h":"1.10872025",
+   *    "low_24h":"1.09666702",
+   *    "open_24h":"1.09737308",
+   *    "close_24h":"1.10774487",
+   *    "best_ask":"1.11144303",
+   *    "best_ask_size":"58.2",
+   *    "best_bid":"1.10795347",
+   *    "best_bid_size":"50.3",
+   *    "fluctuation":"+0.0095",
+   *    "timestamp":1689236985709,
+   *    "url":"https://www.bitmart.com/trade?symbol=EUROC_USDC"}
+   * }
+   * @returns Ticker object
+   */
+  parseTicker(json: any): Ticker {
+    const ticker = {
+      ...this.priceObjectMetadata,
+      ask: this.safeBigNumberParse(json.data.best_ask)!,
+      baseVolume: this.safeBigNumberParse(json.data.base_volume_24h)!,
+      bid: this.safeBigNumberParse(json.data.best_bid)!,
+      lastPrice: this.safeBigNumberParse(json.data.last_price)!,
+      quoteVolume: this.safeBigNumberParse(json.data.quote_volume_24h)!,
+      timestamp: this.safeBigNumberParse(json.data.timestamp)?.toNumber()!,
+    }
+    this.verifyTicker(ticker)
+    return ticker
+  }
+
+  /**
+   *
+   * @param json parsed response from bitmart's trading pair details endpoint
+   * https://api-cloud.bitmart.com/spot/v1/symbols/details
+   *
+   * {
+   * "message":"OK",
+   * "code":1000,
+   * "trace":"48cff315816f4e1aa26ca72cccb46051.69.16892383896653019",
+   * "data":{
+   *  "symbols":[
+   *    { "symbol":"SOLAR_USDT",
+   *      "symbol_id":2342,
+   *      "base_currency":"SOLAR",
+   *      "quote_currency":"USDT",
+   *      "quote_increment":"1",
+   *      "base_min_size":"1.000000000000000000000000000000",
+   *      "price_min_precision":3,
+   *      "price_max_precision":6,
+   *      "expiration":"NA",
+   *      "min_buy_amount":"5.000000000000000000000000000000",
+   *      "min_sell_amount":"5.000000000000000000000000000000",
+   *      "trade_status":"trading"
+   *    },
+   *  ]
+   * }
+   * @returns bool
+   */
+  async isOrderbookLive(): Promise<boolean> {
+    const response = await this.fetchFromApi(
+      ExchangeDataType.ORDERBOOK_STATUS,
+      `spot/v1/symbols/details`
+    )
+    const pair = response?.data.symbols.find(
+      (p: { symbol: string }) => p?.symbol === this.pairSymbol
+    )
+    return !!pair && pair.trade_status === 'trading'
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,6 +82,7 @@ export enum OracleCurrencyPair {
   BTCUSDC = 'BTCUSDC',
   XOFEUR = 'XOFEUR',
   EUROCEUR = 'EUROCEUR',
+  EUROCUSDC = 'EUROCUSDC',
 }
 
 export const CoreCurrencyPair: OracleCurrencyPair[] = [
@@ -120,6 +121,7 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.BTCUSDC]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.USDC },
   [OracleCurrencyPair.XOFEUR]: { base: ExternalCurrency.XOF, quote: ExternalCurrency.EUR },
   [OracleCurrencyPair.EUROCEUR]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.EUR },
+  [OracleCurrencyPair.EUROCUSDC]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.USDC },
 }
 
 export enum AggregationMethod {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,6 @@ export enum ExternalCurrency {
   BRL = 'BRL',
   BUSD = 'BUSD',
   USDC = 'USDC',
-  XOF = 'XOF',
   EUROC = 'EUROC',
 }
 
@@ -80,7 +79,6 @@ export enum OracleCurrencyPair {
   USDCUSDT = 'USDCUSDT',
   EURUSD = 'EURUSD',
   BTCUSDC = 'BTCUSDC',
-  XOFEUR = 'XOFEUR',
   EUROCEUR = 'EUROCEUR',
   EUROCUSDC = 'EUROCUSDC',
 }
@@ -119,7 +117,6 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.BTCUSDT]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.USDT },
   [OracleCurrencyPair.USDCBRL]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.BRL },
   [OracleCurrencyPair.BTCUSDC]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.USDC },
-  [OracleCurrencyPair.XOFEUR]: { base: ExternalCurrency.XOF, quote: ExternalCurrency.EUR },
   [OracleCurrencyPair.EUROCEUR]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.EUR },
   [OracleCurrencyPair.EUROCUSDC]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.USDC },
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,7 @@ export enum Exchange {
   OKX = 'OKX',
   WHITEBIT = 'WHITEBIT',
   BITGET = 'BITGET',
+  BITMART = 'BITMART',
 }
 
 export enum ExternalCurrency {
@@ -48,6 +49,8 @@ export enum ExternalCurrency {
   BRL = 'BRL',
   BUSD = 'BUSD',
   USDC = 'USDC',
+  XOF = 'XOF',
+  EUROC = 'EUROC',
 }
 
 export type Currency = ExternalCurrency | CeloToken
@@ -77,6 +80,8 @@ export enum OracleCurrencyPair {
   USDCUSDT = 'USDCUSDT',
   EURUSD = 'EURUSD',
   BTCUSDC = 'BTCUSDC',
+  XOFEUR = 'XOFEUR',
+  EUROCEUR = 'EUROCEUR',
 }
 
 export const CoreCurrencyPair: OracleCurrencyPair[] = [
@@ -113,6 +118,8 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.BTCUSDT]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.USDT },
   [OracleCurrencyPair.USDCBRL]: { base: ExternalCurrency.USDC, quote: ExternalCurrency.BRL },
   [OracleCurrencyPair.BTCUSDC]: { base: ExternalCurrency.BTC, quote: ExternalCurrency.USDC },
+  [OracleCurrencyPair.XOFEUR]: { base: ExternalCurrency.XOF, quote: ExternalCurrency.EUR },
+  [OracleCurrencyPair.EUROCEUR]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.EUR },
 }
 
 export enum AggregationMethod {

--- a/test/exchange_adapters/bitmart.test.ts
+++ b/test/exchange_adapters/bitmart.test.ts
@@ -34,7 +34,7 @@ describe('BitMart adapter', () => {
       high_24h: '1.10872025',
       low_24h: '1.09676936',
       open_24h: '1.09735661',
-      close_24h: '1.10806017',
+      close_24h: '1.10',
       best_ask: '1.11109875',
       best_ask_size: '51.1',
       best_bid: '1.10756051',
@@ -155,6 +155,44 @@ describe('BitMart adapter', () => {
           trade_status: 'trading',
         },
         {
+          symbol: 'EUROC_USDC',
+          symbol_id: 2632,
+          base_currency: 'EUROC',
+          quote_currency: 'USDC',
+          quote_increment: '0.1',
+          base_min_size: '0.100000000000000000000000000000',
+          price_min_precision: 5,
+          price_max_precision: 8,
+          expiration: 'NA',
+          min_buy_amount: '5.000000000000000000000000000000',
+          min_sell_amount: '5.000000000000000000000000000000',
+          trade_status: 'notTrading',
+        },
+      ],
+    },
+  }
+
+  const inValidMockStatusJson2 = {
+    message: 'OK',
+    code: 1000,
+    trace: '48cff315816f4e1aa26ca72cccb46051.69.16892383896653019',
+    data: {
+      symbols: [
+        {
+          symbol: 'SOLAR_USDT',
+          symbol_id: 2342,
+          base_currency: 'SOLAR',
+          quote_currency: 'USDT',
+          quote_increment: '1',
+          base_min_size: '1.000000000000000000000000000000',
+          price_min_precision: 3,
+          price_max_precision: 6,
+          expiration: 'NA',
+          min_buy_amount: '5.000000000000000000000000000000',
+          min_sell_amount: '5.000000000000000000000000000000',
+          trade_status: 'trading',
+        },
+        {
           symbol: 'EUROC_XOF',
           symbol_id: 2632,
           base_currency: 'EUROC',
@@ -166,7 +204,7 @@ describe('BitMart adapter', () => {
           expiration: 'NA',
           min_buy_amount: '5.000000000000000000000000000000',
           min_sell_amount: '5.000000000000000000000000000000',
-          trade_status: '',
+          trade_status: 'trading',
         },
       ],
     },
@@ -184,6 +222,13 @@ describe('BitMart adapter', () => {
       jest
         .spyOn(bitmartAdapter, 'fetchFromApi')
         .mockReturnValue(Promise.resolve(inValidMockStatusJson))
+      expect(await bitmartAdapter.isOrderbookLive()).toEqual(false)
+    })
+
+    it('returns false if pair is not in response', async () => {
+      jest
+        .spyOn(bitmartAdapter, 'fetchFromApi')
+        .mockReturnValue(Promise.resolve(inValidMockStatusJson2))
       expect(await bitmartAdapter.isOrderbookLive()).toEqual(false)
     })
   })

--- a/test/exchange_adapters/bitmart.test.ts
+++ b/test/exchange_adapters/bitmart.test.ts
@@ -81,7 +81,6 @@ describe('BitMart adapter', () => {
         quoteVolume: new BigNumber(91361.4229378),
         timestamp: 1689239976811,
       })
-      console.log(ticker)
     })
 
     it('throws an error when a json field mapped to a required ticker field is missing or empty', () => {

--- a/test/exchange_adapters/bitmart.test.ts
+++ b/test/exchange_adapters/bitmart.test.ts
@@ -1,0 +1,191 @@
+import { BitMartAdapter } from '../../src/exchange_adapters/bitmart'
+import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
+import { baseLogger } from '../../src/default_config'
+import { Exchange, ExternalCurrency } from '../../src/utils'
+import BigNumber from 'bignumber.js'
+
+describe('BitMart adapter', () => {
+  let bitmartAdapter: BitMartAdapter
+
+  const config: ExchangeAdapterConfig = {
+    baseCurrency: ExternalCurrency.EUROC,
+    baseLogger,
+    quoteCurrency: ExternalCurrency.USDC,
+  }
+
+  beforeEach(() => {
+    bitmartAdapter = new BitMartAdapter(config)
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.clearAllMocks()
+  })
+
+  const validMockTickerJson = {
+    message: 'OK',
+    code: 1000,
+    trace: '48cff315816f4e1aa26ca72cccb46051.58.16892401718550155',
+    data: {
+      symbol: 'EUROC_USDC',
+      last_price: '1.10806017',
+      quote_volume_24h: '91361.42293780',
+      base_volume_24h: '82758.2',
+      high_24h: '1.10872025',
+      low_24h: '1.09676936',
+      open_24h: '1.09735661',
+      close_24h: '1.10806017',
+      best_ask: '1.11109875',
+      best_ask_size: '51.1',
+      best_bid: '1.10756051',
+      best_bid_size: '55.2',
+      fluctuation: '+0.0098',
+      timestamp: 1689239976811,
+      url: 'https://www.bitmart.com/trade?symbol=EUROC_USDC',
+    },
+  }
+
+  const inValidMockTickerJson = {
+    message: 'OK',
+    code: 1000,
+    trace: '48cff315816f4e1aa26ca72cccb46051.58.16892401718550155',
+    data: {
+      symbol: 'EUROC_USDC',
+      last_price: undefined,
+      quote_volume_24h: '91361.42293780',
+      base_volume_24h: undefined,
+      high_24h: '1.10872025',
+      low_24h: '1.09676936',
+      open_24h: '1.09735661',
+      close_24h: '1.10806017',
+      best_ask: undefined,
+      best_ask_size: '51.1',
+      best_bid: undefined,
+      best_bid_size: '55.2',
+      fluctuation: '+0.0098',
+      timestamp: undefined,
+      url: 'https://www.bitmart.com/trade?symbol=EUROC_USDC',
+    },
+  }
+
+  describe('parseTicker', () => {
+    it('handles a response that matches the documentation', () => {
+      const ticker = bitmartAdapter.parseTicker(validMockTickerJson)
+      expect(ticker).toEqual({
+        source: Exchange.BITMART,
+        symbol: bitmartAdapter.standardPairSymbol,
+        ask: new BigNumber(1.11109875),
+        baseVolume: new BigNumber(82758.2),
+        bid: new BigNumber(1.10756051),
+        lastPrice: new BigNumber(1.10806017),
+        quoteVolume: new BigNumber(91361.4229378),
+        timestamp: 1689239976811,
+      })
+      console.log(ticker)
+    })
+
+    it('throws an error when a json field mapped to a required ticker field is missing or empty', () => {
+      expect(() => {
+        bitmartAdapter.parseTicker(inValidMockTickerJson)
+      }).toThrowError('timestamp, bid, ask, lastPrice, baseVolume not defined')
+    })
+  })
+
+  describe('fetchTrades', () => {
+    it('returns empty array', async () => {
+      expect(await bitmartAdapter.fetchTrades()).toEqual([])
+    })
+  })
+
+  const validMockStatusJson = {
+    message: 'OK',
+    code: 1000,
+    trace: '48cff315816f4e1aa26ca72cccb46051.69.16892383896653019',
+    data: {
+      symbols: [
+        {
+          symbol: 'SOLAR_USDT',
+          symbol_id: 2342,
+          base_currency: 'SOLAR',
+          quote_currency: 'USDT',
+          quote_increment: '1',
+          base_min_size: '1.000000000000000000000000000000',
+          price_min_precision: 3,
+          price_max_precision: 6,
+          expiration: 'NA',
+          min_buy_amount: '5.000000000000000000000000000000',
+          min_sell_amount: '5.000000000000000000000000000000',
+          trade_status: '',
+        },
+        {
+          symbol: 'EUROC_USDC',
+          symbol_id: 2632,
+          base_currency: 'EUROC',
+          quote_currency: 'USDC',
+          quote_increment: '0.1',
+          base_min_size: '0.100000000000000000000000000000',
+          price_min_precision: 5,
+          price_max_precision: 8,
+          expiration: 'NA',
+          min_buy_amount: '5.000000000000000000000000000000',
+          min_sell_amount: '5.000000000000000000000000000000',
+          trade_status: 'trading',
+        },
+      ],
+    },
+  }
+
+  const inValidMockStatusJson = {
+    message: 'OK',
+    code: 1000,
+    trace: '48cff315816f4e1aa26ca72cccb46051.69.16892383896653019',
+    data: {
+      symbols: [
+        {
+          symbol: 'SOLAR_USDT',
+          symbol_id: 2342,
+          base_currency: 'SOLAR',
+          quote_currency: 'USDT',
+          quote_increment: '1',
+          base_min_size: '1.000000000000000000000000000000',
+          price_min_precision: 3,
+          price_max_precision: 6,
+          expiration: 'NA',
+          min_buy_amount: '5.000000000000000000000000000000',
+          min_sell_amount: '5.000000000000000000000000000000',
+          trade_status: 'trading',
+        },
+        {
+          symbol: 'EUROC_XOF',
+          symbol_id: 2632,
+          base_currency: 'EUROC',
+          quote_currency: 'USDC',
+          quote_increment: '0.1',
+          base_min_size: '0.100000000000000000000000000000',
+          price_min_precision: 5,
+          price_max_precision: 8,
+          expiration: 'NA',
+          min_buy_amount: '5.000000000000000000000000000000',
+          min_sell_amount: '5.000000000000000000000000000000',
+          trade_status: '',
+        },
+      ],
+    },
+  }
+
+  describe('isOrderbookLive', () => {
+    it('returns true if trade_status is trading', async () => {
+      jest
+        .spyOn(bitmartAdapter, 'fetchFromApi')
+        .mockReturnValue(Promise.resolve(validMockStatusJson))
+      expect(await bitmartAdapter.isOrderbookLive()).toEqual(true)
+    })
+
+    it('returns false if trade_status is not trading', async () => {
+      jest
+        .spyOn(bitmartAdapter, 'fetchFromApi')
+        .mockReturnValue(Promise.resolve(inValidMockStatusJson))
+      expect(await bitmartAdapter.isOrderbookLive()).toEqual(false)
+    })
+  })
+})


### PR DESCRIPTION
## Description

This Pr adds a new exchange Adapter for Bitmart that we need for EUROCEUR reports.
The ticket mentions some additional adapters for FX rates since it seems like there are better data providers that provide more information than just the price. I would suggest we separate the ticket until we decide on which providers to use @sissnad

## Other changes

- N/A

## Tested

- unit tests for the new adapter
- ran oracle locally to verify prices are being reported 
-> add  `[{ exchange: 'BITMART', symbol: 'EUROCUSDC', toInvert: false }],` to devPriceSourcesConfig.txt

## Related issues

- Fixes [239](https://github.com/mento-protocol/mento-general/issues/239)

## Backwards compatibility

