### PR TITLE
chore: Remove unused 'trades' related code

### DIFF
--- a/src/exchange_adapters/bitget.ts
+++ b/src/exchange_adapters/bitget.ts
@@ -1,5 +1,6 @@
+import { BaseExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
 
 export class BitgetAdapter extends BaseExchangeAdapter {
   baseApiUrl = 'https://api.bitget.com/api'
@@ -16,14 +17,6 @@ export class BitgetAdapter extends BaseExchangeAdapter {
         `spot/v1/market/ticker?symbol=${this.pairSymbol}_SPBL`
       )
     )
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    /**
-     * Trades are cool, but empty arrays are cooler.
-     *                          @bogdan, 01/2023
-     */
-    return []
   }
 
   protected generatePairSymbol(): string {
@@ -75,7 +68,7 @@ export class BitgetAdapter extends BaseExchangeAdapter {
 
   /**
    * Checks if the orderbook for the relevant pair is live. If it's not, the price
-   * data from Ticker + Trade endpoints may be inaccurate.
+   * data from Ticker endpoint may be inaccurate.
    *
    * https://api.bitget.com/api/spot/v1/public/product?symbol=BTCBRL_SPBL
    *

--- a/src/exchange_adapters/bitmart.ts
+++ b/src/exchange_adapters/bitmart.ts
@@ -1,5 +1,6 @@
+import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
 
 export class BitMartAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api-cloud.bitmart.com'
@@ -20,14 +21,6 @@ export class BitMartAdapter extends BaseExchangeAdapter implements ExchangeAdapt
       `spot/v1/ticker_detail?symbol=${this.pairSymbol}`
     )
     return this.parseTicker(tickerJson)
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    // Trade data is not needed by oracle but is required by the parent class.
-    // This function along with all other functions that are not needed by the oracle will
-    // be removed in a future PR.
-    // -- @bayological ;) --
-    return []
   }
 
   /**

--- a/src/exchange_adapters/bitso.ts
+++ b/src/exchange_adapters/bitso.ts
@@ -1,5 +1,6 @@
+import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
 
 export class BitsoAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.bitso.com/api/v3'
@@ -22,14 +23,6 @@ export class BitsoAdapter extends BaseExchangeAdapter implements ExchangeAdapter
       `ticker?book=${this.pairSymbol}`
     )
     return this.parseTicker(tickerJson.payload)
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    const tradesJson = await this.fetchFromApi(
-      ExchangeDataType.TRADE,
-      `trades?book=${this.pairSymbol}`
-    )
-    return this.parseTrades(tradesJson.payload).sort((a, b) => a.timestamp - b.timestamp)
   }
 
   /**
@@ -68,39 +61,6 @@ export class BitsoAdapter extends BaseExchangeAdapter implements ExchangeAdapter
     }
     this.verifyTicker(ticker)
     return ticker
-  }
-
-  /**
-   *
-   * @param json response from Bitso's trades endpoint
-   *
-   * [
-   *     {
-   *         "book": "btc_mxn",
-   *         "created_at": "2021-07-02T05:54:45+0000",
-   *         "amount": "0.00127843",
-   *         "maker_side": "buy",
-   *         "price": "659436.40",
-   *         "tid": 41827090
-   *     }
-   * ]
-   */
-  parseTrades(json: any): Trade[] {
-    return json.map((trade: any) => {
-      const price = this.safeBigNumberParse(trade.price)
-      const amount = this.safeBigNumberParse(trade.amount)
-      const normalizedTrade = {
-        ...this.priceObjectMetadata,
-        amount,
-        cost: amount ? price?.times(amount) : undefined,
-        id: trade.tid,
-        price,
-        side: trade.maker_side,
-        timestamp: this.safeDateParse(trade.created_at)!,
-      }
-      this.verifyTrade(normalizedTrade)
-      return normalizedTrade
-    })
   }
 
   /**

--- a/src/exchange_adapters/bitstamp.ts
+++ b/src/exchange_adapters/bitstamp.ts
@@ -1,5 +1,6 @@
+import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
 
 export class BitstampAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://www.bitstamp.net/api/v2'
@@ -18,14 +19,6 @@ export class BitstampAdapter extends BaseExchangeAdapter implements ExchangeAdap
   async fetchTicker(): Promise<Ticker> {
     const tickerJson = await this.fetchFromApi(ExchangeDataType.TICKER, `ticker/${this.pairSymbol}`)
     return this.parseTicker(tickerJson)
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    // Trade data is not needed by oracle but is required by the parent class.
-    // This function along with all other functions that are not needed by the oracle will
-    // be removed in a future PR.
-    // -- @bayological ;) --
-    return []
   }
 
   /**

--- a/src/exchange_adapters/gemini.ts
+++ b/src/exchange_adapters/gemini.ts
@@ -1,5 +1,6 @@
+import { BaseExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
 
 export class GeminiAdapter extends BaseExchangeAdapter {
   baseApiUrl = 'https://api.gemini.com/v1/'
@@ -13,14 +14,6 @@ export class GeminiAdapter extends BaseExchangeAdapter {
     return this.parseTicker(
       await this.fetchFromApi(ExchangeDataType.TICKER, `pubticker/${this.pairSymbol}`)
     )
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    /**
-     * Trades are cool, but empty arrays are cooler.
-     *                          @bogdan, 01/2023
-     */
-    return []
   }
 
   protected generatePairSymbol(): string {
@@ -68,7 +61,7 @@ export class GeminiAdapter extends BaseExchangeAdapter {
 
   /**
    * Checks if the orderbook for the relevant pair is live. If it's not, the price
-   * data from Ticker + Trade endpoints may be inaccurate.
+   * data from ticker endpoint may be inaccurate.
    *
    * API response example:
    * {

--- a/src/exchange_adapters/kraken.ts
+++ b/src/exchange_adapters/kraken.ts
@@ -1,5 +1,6 @@
+import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
 
 export class KrakenAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.kraken.com'
@@ -23,14 +24,6 @@ export class KrakenAdapter extends BaseExchangeAdapter implements ExchangeAdapte
       `0/public/Ticker?pair=${this.pairSymbol}`
     )
     return this.parseTicker(json)
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    // Trade data is not needed by oracle but is required by the parent class.
-    // This function along with all other functions that are not needed by the oracle will
-    // be removed in a future PR.
-    // -- @bayological ;) --
-    return []
   }
 
   /**

--- a/src/exchange_adapters/kucoin.ts
+++ b/src/exchange_adapters/kucoin.ts
@@ -1,5 +1,6 @@
+import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
 
 export class KuCoinAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.kucoin.com'
@@ -19,14 +20,6 @@ export class KuCoinAdapter extends BaseExchangeAdapter implements ExchangeAdapte
     const tickerJson = await this.fetchFromApi(ExchangeDataType.TICKER, `api/v1/market/allTickers`)
 
     return this.parseTicker(tickerJson)
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    // Trade data is not needed by oracle but is required by the parent class.
-    // This function along with all other functions that are not needed by the oracle will
-    // be removed in a future PR.
-    // -- @bayological ;) --
-    return []
   }
 
   /**

--- a/src/exchange_adapters/mercado.ts
+++ b/src/exchange_adapters/mercado.ts
@@ -1,5 +1,7 @@
+import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
+
 export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.mercadobitcoin.net/api/v4'
   readonly _exchangeName = Exchange.MERCADO
@@ -20,14 +22,6 @@ export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapt
       this.fetchFromApi(ExchangeDataType.TICKER, `${this.pairSymbol}/orderbook`),
     ])
     return this.parseTicker(tickerJson, orderbookJson)
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    // Trade data is not needed by oracle but is required by the parent class.
-    // This function along with all other functions that are not needed by the oracle will
-    // be removed in a future PR.
-    // -- @bayological ;) --
-    return []
   }
 
   /**

--- a/src/exchange_adapters/novadax.ts
+++ b/src/exchange_adapters/novadax.ts
@@ -1,5 +1,6 @@
+import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
 
 export class NovaDaxAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.novadax.com/v1/market'
@@ -22,14 +23,6 @@ export class NovaDaxAdapter extends BaseExchangeAdapter implements ExchangeAdapt
       `ticker?symbol=${this.pairSymbol}`
     )
     return this.parseTicker(tickerJson)
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    const tradesJson = await this.fetchFromApi(
-      ExchangeDataType.TRADE,
-      `trades?symbol=${this.pairSymbol}`
-    )
-    return this.parseTrades(tradesJson.payload).sort((a, b) => a.timestamp - b.timestamp)
   }
 
   /**
@@ -73,49 +66,6 @@ export class NovaDaxAdapter extends BaseExchangeAdapter implements ExchangeAdapt
     }
     this.verifyTicker(ticker)
     return ticker
-  }
-
-  /**
-   *
-   * @param json response from NovaDax's trades endpoint
-   *
-   *  {
-   *      "code": "A10000",
-   *      "data": [
-   *          {
-   *              "price": "43657.57",
-   *              "amount": "1",
-   *              "side": "SELL",
-   *              "timestamp": 1565007823401
-   *          },
-   *          {
-   *              "price": "43687.16",
-   *              "amount": "0.071",
-   *              "side": "BUY",
-   *              "timestamp": 1565007198261
-   *          }
-   *      ],
-   *      "message": "Success"
-   *  }
-   *
-   */
-
-  parseTrades(json: any): Trade[] {
-    return json.data.map((trade: any) => {
-      const price = this.safeBigNumberParse(trade.price)
-      const amount = this.safeBigNumberParse(trade.amount)
-      const normalizedTrade = {
-        ...this.priceObjectMetadata,
-        amount,
-        cost: amount ? price?.times(amount) : undefined,
-        // no trade id
-        price,
-        side: trade.side.toLowerCase(),
-        timestamp: this.safeBigNumberParse(trade.created_at)!.toNumber(),
-      }
-      this.verifyTrade(normalizedTrade)
-      return normalizedTrade
-    })
   }
 
   /**

--- a/src/exchange_adapters/okcoin.ts
+++ b/src/exchange_adapters/okcoin.ts
@@ -1,5 +1,6 @@
+import { BaseExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
 
 export class OKCoinAdapter extends BaseExchangeAdapter {
   baseApiUrl = 'https://www.okcoin.com/api'
@@ -19,14 +20,6 @@ export class OKCoinAdapter extends BaseExchangeAdapter {
       `spot/v3/instruments/${this.pairSymbol}/ticker`
     )
     return this.parseTicker(json)
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    const tradeJson = await this.fetchFromApi(
-      ExchangeDataType.TRADE,
-      `spot/v3/instruments/${this.pairSymbol}/trades`
-    )
-    return this.parseTrades(tradeJson)
   }
 
   /**
@@ -69,44 +62,6 @@ export class OKCoinAdapter extends BaseExchangeAdapter {
     }
     this.verifyTicker(ticker)
     return ticker
-  }
-
-  /**
-   * Parses the response from the trades endpoint and returns an array of standard
-   * Trade objects.
-   *
-   * @param json response from /spot/v3/instruments/${this.pairSymbol}/trades
-   *
-   *    Example response from OKCoin Docs: https://www.okcoin.com/docs/en/#spot-deal_information
-   *
-   *    [
-   *      {
-   *        "time":"2019-04-12T02:07:30.523Z",
-   *        "timestamp":"2019-04-12T02:07:30.523Z",
-   *        "trade_id":"1296412902",
-   *        "price":"4913.4",
-   *        "size":"0.00990734",
-   *        "side":"buy"
-   *      }
-   *    ]
-   */
-  parseTrades(json: any): Trade[] {
-    return json.map((trade: any) => {
-      const price = this.safeBigNumberParse(trade.price)
-      const amount = this.safeBigNumberParse(trade.size)
-      const cost = amount ? price?.times(amount) : undefined
-      const normalizedTrade = {
-        ...this.priceObjectMetadata,
-        amount,
-        cost,
-        id: trade.trade_id,
-        price,
-        side: trade.side,
-        timestamp: this.safeDateParse(trade.timestamp),
-      }
-      this.verifyTrade(normalizedTrade)
-      return normalizedTrade
-    })
   }
 
   protected generatePairSymbol(): string {

--- a/src/exchange_adapters/okx.ts
+++ b/src/exchange_adapters/okx.ts
@@ -1,5 +1,6 @@
+import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
 import { Exchange } from '../utils'
-import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
 
 export class OKXAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://www.okx.com/api/v5'
@@ -22,14 +23,6 @@ export class OKXAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
     )
 
     return this.parseTicker(tickerJson)
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    // Trade data is not needed by oracle but is required by the parent class.
-    // This function along with all other functions that are not needed by the oracle will
-    // be removed in a future PR.
-    // -- @bayological ;) --
-    return []
   }
 
   /**

--- a/src/exchange_adapters/whitebit.ts
+++ b/src/exchange_adapters/whitebit.ts
@@ -1,4 +1,4 @@
-import { BaseExchangeAdapter, ExchangeDataType, Ticker, Trade } from './base'
+import { BaseExchangeAdapter, ExchangeDataType, Ticker } from './base'
 
 import { Exchange } from '../utils'
 
@@ -16,15 +16,6 @@ export class WhitebitAdapter extends BaseExchangeAdapter {
     const quote = WhitebitAdapter.tokenSymbolMap.get(this.config.quoteCurrency)?.toUpperCase()
 
     return `${base}_${quote}`
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    // "An empty array in TypeScript may seem insignificant,
-    //    but it holds within it the infinite potential of
-    //          all the elements yet to come."
-    // -- @bayological --
-
-    return []
   }
 
   async fetchTicker(): Promise<Ticker> {

--- a/test/exchange_adapters/base.test.ts
+++ b/test/exchange_adapters/base.test.ts
@@ -1,8 +1,4 @@
-import {
-  BaseExchangeAdapter,
-  ExchangeDataType,
-  Ticker,
-} from '../../src/exchange_adapters/base'
+import { BaseExchangeAdapter, ExchangeDataType, Ticker } from '../../src/exchange_adapters/base'
 import { Exchange, ExternalCurrency } from '../../src/utils'
 import { ExchangeApiRequestError, MetricCollector } from '../../src/metric_collector'
 

--- a/test/exchange_adapters/base.test.ts
+++ b/test/exchange_adapters/base.test.ts
@@ -97,16 +97,14 @@ describe('BaseExchangeAdapter', () => {
         fetch.mockReturnValue(Promise.resolve(new Response(mockJsonResponse, { status: 200 })))
       })
 
-      for (const dataType of [ExchangeDataType.TICKER]) {
-        it(`returns a parsed json response for ${dataType}`, async () => {
-          const path = `CELO-USD/${dataType.toLowerCase()}`
-          const response = await adapter.fetchFromApi(dataType, path)
+      it(`returns a parsed json response for ticker`, async () => {
+        const path = `CELO-USD/${ExchangeDataType.TICKER.toLowerCase()}`
+        const response = await adapter.fetchFromApi(ExchangeDataType.TICKER, path)
 
-          expect(response).toEqual({ fake: 'jsonValue' })
+        expect(response).toEqual({ fake: 'jsonValue' })
 
-          expect(fetch).toHaveBeenCalledWith(expect.stringContaining(path), expect.anything())
-        })
-      }
+        expect(fetch).toHaveBeenCalledWith(expect.stringContaining(path), expect.anything())
+      })
 
       it('collects metrics', async () => {
         await adapter.fetchFromApi(ExchangeDataType.TICKER, mockTickerEndpoint)

--- a/test/exchange_adapters/bitget.test.ts
+++ b/test/exchange_adapters/bitget.test.ts
@@ -1,8 +1,9 @@
-import BigNumber from 'bignumber.js'
-import { baseLogger } from '../../src/default_config'
-import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
-import { BitgetAdapter } from '../../src/exchange_adapters/bitget'
 import { Exchange, ExternalCurrency } from '../../src/utils'
+
+import BigNumber from 'bignumber.js'
+import { BitgetAdapter } from '../../src/exchange_adapters/bitget'
+import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
+import { baseLogger } from '../../src/default_config'
 
 describe('BitgetAdapter', () => {
   let bitgetAdapter: BitgetAdapter
@@ -33,13 +34,6 @@ describe('BitgetAdapter', () => {
     msg: 'success',
     requestTime: '1677490448872', // Request status
   }
-
-  describe('fetchTrades', () => {
-    it('returns an empty array', async () => {
-      const tradesFetched = await bitgetAdapter.fetchTrades()
-      expect(tradesFetched).toEqual([])
-    })
-  })
 
   describe('parseTicker', () => {
     it('handles a response that matches the documentation', () => {

--- a/test/exchange_adapters/bitmart.test.ts
+++ b/test/exchange_adapters/bitmart.test.ts
@@ -1,8 +1,9 @@
+import { Exchange, ExternalCurrency } from '../../src/utils'
+
+import BigNumber from 'bignumber.js'
 import { BitMartAdapter } from '../../src/exchange_adapters/bitmart'
 import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
 import { baseLogger } from '../../src/default_config'
-import { Exchange, ExternalCurrency } from '../../src/utils'
-import BigNumber from 'bignumber.js'
 
 describe('BitMart adapter', () => {
   let bitmartAdapter: BitMartAdapter
@@ -87,12 +88,6 @@ describe('BitMart adapter', () => {
       expect(() => {
         bitmartAdapter.parseTicker(inValidMockTickerJson)
       }).toThrowError('timestamp, bid, ask, lastPrice, baseVolume not defined')
-    })
-  })
-
-  describe('fetchTrades', () => {
-    it('returns empty array', async () => {
-      expect(await bitmartAdapter.fetchTrades()).toEqual([])
     })
   })
 

--- a/test/exchange_adapters/bitstamp.test.ts
+++ b/test/exchange_adapters/bitstamp.test.ts
@@ -1,8 +1,9 @@
+import { Exchange, ExternalCurrency } from '../../src/utils'
+
+import BigNumber from 'bignumber.js'
 import { BitstampAdapter } from '../../src/exchange_adapters/bitstamp'
 import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
 import { baseLogger } from '../../src/default_config'
-import { Exchange, ExternalCurrency } from '../../src/utils'
-import BigNumber from 'bignumber.js'
 
 describe('Bitstamp adapter', () => {
   let bitstampAdapter: BitstampAdapter
@@ -117,12 +118,6 @@ describe('Bitstamp adapter', () => {
       expect(() => {
         bitstampAdapter.parseTicker(inValidMockTickerJson)
       }).toThrowError('bid, ask, lastPrice, baseVolume not defined')
-    })
-  })
-
-  describe('fetchTrades', () => {
-    it('returns empty array', async () => {
-      expect(await bitstampAdapter.fetchTrades()).toEqual([])
     })
   })
 

--- a/test/exchange_adapters/bittrex.test.ts
+++ b/test/exchange_adapters/bittrex.test.ts
@@ -1,9 +1,10 @@
-import { CeloContract } from '@celo/contractkit'
-import BigNumber from 'bignumber.js'
-import { baseLogger } from '../../src/default_config'
-import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
-import { BittrexAdapter } from '../../src/exchange_adapters/bittrex'
 import { Exchange, ExternalCurrency } from '../../src/utils'
+
+import BigNumber from 'bignumber.js'
+import { BittrexAdapter } from '../../src/exchange_adapters/bittrex'
+import { CeloContract } from '@celo/contractkit'
+import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
+import { baseLogger } from '../../src/default_config'
 
 describe('BittrexAdapter', () => {
   let bittrexAdapter: BittrexAdapter
@@ -75,70 +76,7 @@ describe('BittrexAdapter', () => {
       }).toThrowError('timestamp not defined')
     })
   })
-  describe('parseTrades', () => {
-    const goodTrade1 = {
-      id: '8b9fc1be-3f62-480a-bb06-d91cac27fed9',
-      executedAt: '2020-05-20T12:45:03.71Z',
-      quantity: '1.00000000',
-      rate: '214.30100000',
-      takerSide: 'BUY',
-    }
-    const goodTrade2 = {
-      id: '81993afb-06f3-4f41-a32b-60f0d4ec9d4c',
-      executedAt: '2020-05-20T12:39:09.85Z',
-      quantity: '0.04824285',
-      rate: '214.02100000',
-      takerSide: 'SELL',
-    }
-    const goodTradeArray = [goodTrade1, goodTrade2]
 
-    it('handles correctly formatted trades', () => {
-      const result = bittrexAdapter.parseTrades(goodTradeArray)
-      expect(result).toEqual([
-        {
-          source: Exchange.BITTREX,
-          id: '8b9fc1be-3f62-480a-bb06-d91cac27fed9',
-          timestamp: 1589978703710,
-          symbol: bittrexAdapter.standardPairSymbol,
-          side: 'BUY',
-          price: new BigNumber(214.301),
-          amount: new BigNumber(1),
-          cost: new BigNumber(214.301),
-        },
-        {
-          source: Exchange.BITTREX,
-          id: '81993afb-06f3-4f41-a32b-60f0d4ec9d4c',
-          timestamp: 1589978349850,
-          symbol: bittrexAdapter.standardPairSymbol,
-          side: 'SELL',
-          price: new BigNumber(214.021),
-          amount: new BigNumber(0.04824285),
-          cost: new BigNumber(10.32498299985),
-        },
-      ])
-    })
-    it('throws an error if a number field was not reasonably parsed', () => {
-      expect(() => {
-        bittrexAdapter.parseTrades([
-          {
-            ...goodTrade1,
-            rate: 'two_hundred_something!',
-          },
-          goodTrade2,
-        ])
-      }).toThrow('price, cost not defined')
-    })
-    it('throws an error if the date could not be parsed', () => {
-      expect(() => {
-        bittrexAdapter.parseTrades([
-          {
-            ...goodTrade2,
-            executedAt: '71st March, 2020, 25:06',
-          },
-        ])
-      }).toThrowError('timestamp not defined')
-    })
-  })
   describe('isOrderbookLive', () => {
     const mockStatusJson = {
       symbol: 'CELO-USD',

--- a/test/exchange_adapters/gemini.test.ts
+++ b/test/exchange_adapters/gemini.test.ts
@@ -1,8 +1,9 @@
+import { Exchange, ExternalCurrency } from '../../src/utils'
+
 import BigNumber from 'bignumber.js'
-import { baseLogger } from '../../src/default_config'
 import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
 import { GeminiAdapter } from '../../src/exchange_adapters/gemini'
-import { Exchange, ExternalCurrency } from '../../src/utils'
+import { baseLogger } from '../../src/default_config'
 
 describe('GeminiAdapter', () => {
   let geminiAdapter: GeminiAdapter
@@ -29,13 +30,6 @@ describe('GeminiAdapter', () => {
       timestamp: 1483018200000,
     },
   }
-
-  describe('fetchTrades', () => {
-    it('returns an empty array', async () => {
-      const tradesFetched = await geminiAdapter.fetchTrades()
-      expect(tradesFetched).toEqual([])
-    })
-  })
 
   describe('parseTicker', () => {
     it('handles a response that matches the documentation', () => {

--- a/test/exchange_adapters/kucoin.test.ts
+++ b/test/exchange_adapters/kucoin.test.ts
@@ -1,9 +1,10 @@
-import { KuCoinAdapter } from '../../src/exchange_adapters/kucoin'
+import { Exchange, ExternalCurrency } from '../../src/utils'
+
+import BigNumber from 'bignumber.js'
 import { CeloContract } from '@celo/contractkit'
 import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
+import { KuCoinAdapter } from '../../src/exchange_adapters/kucoin'
 import { baseLogger } from '../../src/default_config'
-import { Exchange, ExternalCurrency } from '../../src/utils'
-import BigNumber from 'bignumber.js'
 
 describe('KuCoin adapter', () => {
   let kucoinAdapter: KuCoinAdapter
@@ -132,12 +133,6 @@ describe('KuCoin adapter', () => {
       expect(() => {
         kucoinAdapter.parseTicker(inValidMockTickerJson)
       }).toThrowError('timestamp, bid, ask, lastPrice, baseVolume not defined')
-    })
-  })
-
-  describe('fetchTrades', () => {
-    it('returns empty array', async () => {
-      expect(await kucoinAdapter.fetchTrades()).toEqual([])
     })
   })
 

--- a/test/exchange_adapters/mercado.test.ts
+++ b/test/exchange_adapters/mercado.test.ts
@@ -1,8 +1,9 @@
-import { MercadoAdapter } from '../../src/exchange_adapters/mercado'
-import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
-import { baseLogger } from '../../src/default_config'
 import { Exchange, ExternalCurrency } from '../../src/utils'
+
 import BigNumber from 'bignumber.js'
+import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
+import { MercadoAdapter } from '../../src/exchange_adapters/mercado'
+import { baseLogger } from '../../src/default_config'
 
 describe(' adapter', () => {
   let mercadoAdapter: MercadoAdapter
@@ -85,12 +86,6 @@ describe(' adapter', () => {
       expect(() => {
         mercadoAdapter.parseTicker(inValidMockTickerJson, inValidOrderbookJson)
       }).toThrowError('bid, ask, lastPrice, baseVolume not defined')
-    })
-  })
-
-  describe('fetchTrades', () => {
-    it('returns empty array', async () => {
-      expect(await mercadoAdapter.fetchTrades()).toEqual([])
     })
   })
 

--- a/test/exchange_adapters/okcoin.test.ts
+++ b/test/exchange_adapters/okcoin.test.ts
@@ -1,9 +1,10 @@
-import { CeloContract } from '@celo/contractkit'
+import { Exchange, ExternalCurrency } from '../../src/utils'
+
 import BigNumber from 'bignumber.js'
-import { baseLogger } from '../../src/default_config'
+import { CeloContract } from '@celo/contractkit'
 import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
 import { OKCoinAdapter } from '../../src/exchange_adapters/okcoin'
-import { Exchange, ExternalCurrency } from '../../src/utils'
+import { baseLogger } from '../../src/default_config'
 
 describe('OKCoinAdapter', () => {
   let okcoinAdapter: OKCoinAdapter
@@ -73,65 +74,6 @@ describe('OKCoinAdapter', () => {
           timestamp: 'the 20th of May, 2020 at 1:22 pm',
         })
       }).toThrowError('timestamp not defined')
-    })
-  })
-  describe('parseTrades', () => {
-    // Slightly modified example from their docs
-    const goodTrade1 = {
-      time: '2019-04-12T02:07:30.523Z',
-      timestamp: '2019-04-12T02:07:30.523Z',
-      trade_id: '1296412902',
-      price: '4913.4',
-      size: '0.0099',
-      side: 'buy',
-    }
-    const goodTrade2 = {
-      time: '2019-04-12T02:07:30.455Z',
-      timestamp: '2019-04-12T02:07:30.455Z',
-      trade_id: '1296412899',
-      price: '4913.2',
-      size: '0.17',
-      side: 'sell',
-    }
-    const goodTradeArray = [goodTrade1, goodTrade2]
-
-    it('handles correctly formatted trades', () => {
-      const result = okcoinAdapter.parseTrades(goodTradeArray)
-      expect(result).toEqual([
-        {
-          amount: new BigNumber(0.0099),
-          cost: new BigNumber(48.64266),
-          id: '1296412902',
-          price: new BigNumber(4913.4),
-          side: 'buy',
-          source: Exchange.OKCOIN,
-          symbol: okcoinAdapter.standardPairSymbol,
-          timestamp: 1555034850523,
-        },
-        {
-          amount: new BigNumber(0.17),
-          cost: new BigNumber(835.244),
-          id: '1296412899',
-          price: new BigNumber(4913.2),
-          side: 'sell',
-          source: Exchange.OKCOIN,
-          symbol: okcoinAdapter.standardPairSymbol,
-          timestamp: 1555034850455,
-        },
-      ])
-    })
-    it('throws an error if a required field is missing on one trade', () => {
-      expect(() => {
-        okcoinAdapter.parseTrades([
-          {
-            ...goodTrade1,
-            price: undefined,
-            trade_id: undefined,
-            size: undefined,
-          },
-          goodTrade2,
-        ])
-      }).toThrowError('id, price, amount, cost not defined')
     })
   })
 })

--- a/test/exchange_adapters/okx.test.ts
+++ b/test/exchange_adapters/okx.test.ts
@@ -1,9 +1,10 @@
+import { Exchange, ExternalCurrency } from '../../src/utils'
+
 import BigNumber from 'bignumber.js'
-import { baseLogger } from '../../src/default_config'
+import { CeloContract } from '@celo/contractkit'
 import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
 import { OKXAdapter } from '../../src/exchange_adapters/okx'
-import { Exchange, ExternalCurrency } from '../../src/utils'
-import { CeloContract } from '@celo/contractkit'
+import { baseLogger } from '../../src/default_config'
 
 describe('OKXAdapter', () => {
   let okxAdapter: OKXAdapter
@@ -68,13 +69,6 @@ describe('OKXAdapter', () => {
       },
     ],
   }
-
-  describe('fetchTrades', () => {
-    it('returns an empty array', async () => {
-      const tradesFetched = await okxAdapter.fetchTrades()
-      expect(tradesFetched).toEqual([])
-    })
-  })
 
   describe('parseTicker', () => {
     it('handles a response that matches the documentation', () => {

--- a/test/exchange_price_source.test.ts
+++ b/test/exchange_price_source.test.ts
@@ -1,14 +1,15 @@
-import { ExchangeAdapter, Ticker, Trade } from '../src/exchange_adapters/base'
-import BigNumber from 'bignumber.js'
-import { Exchange } from '../src/utils'
+import { ExchangeAdapter, Ticker } from '../src/exchange_adapters/base'
 import {
   ExchangePriceSource,
   OrientedAdapter,
   PairData,
   impliedPair,
 } from '../src/exchange_price_source'
-import { baseLogger } from '../src/default_config'
+
+import BigNumber from 'bignumber.js'
+import { Exchange } from '../src/utils'
 import { MetricCollector } from '../src/metric_collector'
+import { baseLogger } from '../src/default_config'
 
 jest.mock('../src/metric_collector')
 
@@ -21,11 +22,6 @@ class MockAdapter implements ExchangeAdapter {
     this.ticker = ticker
     this.pairSymbol = ticker.symbol
     this.exchangeName = ticker.source
-  }
-
-  async fetchTrades(): Promise<Trade[]> {
-    // Trades are not used.
-    return [] as Trade[]
   }
 
   async fetchTicker(): Promise<Ticker> {


### PR DESCRIPTION
## Description

This removes all of the unused code related to trades in the codebase. I recently noticed it again in @philbow61 PR to add the [bitmart adapter](https://github.com/celo-org/celo-oracle/pull/177/files#diff-95a3025b2559ff66f41c653df3c49e0f47a2523c0e1cec17c8985bff2de3032fR25-R31) and decided to take some time to finally get rid of it.

The background on this is that at some point we thought we might want to use both trade and ticket data but we only ended up using the later.

## Other changes

Order changes on the imports were done by the linter

## Tested

Ran the client locally for two different currency pairs

## Related issues

- Fixes https://github.com/celo-org/celo-oracle/issues/178
