### PR TITLE
chore: update docker image to node:18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # docker push oracletest.azurecr.io/test/oracle:$COMMIT_SHA
 
 # First stage, builder to install devDependencies to build TypeScript
-FROM node:12 as BUILDER
+FROM node:18 as BUILDER
 
 RUN apt-get update
 RUN apt-get install -y libusb-1.0-0-dev
@@ -28,7 +28,7 @@ COPY src src
 RUN yarn build
 
 # Second stage, create slimmed down production-ready image
-FROM node:12
+FROM node:18
 ARG COMMIT_SHA
 
 RUN apt-get update

--- a/dockerfiles/continuous-integration/Dockerfile
+++ b/dockerfiles/continuous-integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:18
 
 RUN apt-get update
 RUN apt-get install -y libusb-1.0-0-dev


### PR DESCRIPTION
## Description

updating the node version + debian 

## Other changes

n/a

## Tested

pushed a new [docker image](https://console.cloud.google.com/artifacts/docker/celo-testnet-production/us-west1/celo-oracle/celo-oracle/sha256:531ea25700df3c25e918af39aee354a9b67e3b80da268cb39029da1f76d36ae4) in the registry 

## Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/261

## Backwards compatibility

n/a
