### PR TITLE
chore: bump version to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "celo-oracle",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Oracle application to aggregate and report exchange rates to the Celo network",
   "author": "Celo",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Description**

New pair was added recently by @sissnad in this [pr](https://github.com/celo-org/celo-oracle/pull/183) therefore I'm bumping version to 1.0.5