### PR TITLE
chore: update latest recommended config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ yarn start | npx bunyan
 
 Docker images are pushed to a public container [registry](https://console.cloud.google.com/artifacts/docker/celo-testnet-production/us-west1/celo-oracle/celo-oracle) upon every release. The latest price sources and data aggregation parameters can be found as helm charts in the celo [monorepo](https://github.com/celo-org/celo-monorepo/tree/master/packages/helm-charts/oracle).
 
-The recommended configuration at the moment is [76f02ea](https://github.com/celo-org/celo-monorepo/tree/76f02ea65b9284f3d0e47e256dece82dc0747a6e/packages/helm-charts/oracle).
+The recommended configuration at the moment is [0d433bc](https://github.com/celo-org/celo-monorepo/tree/0d433bc6b3bb0845868660281320d0a4fbba3dee/packages/helm-charts/oracle).
 
 
 ## Component Overview


### PR DESCRIPTION
## Description

It should point to the EUROC/EUR config that was just merged 
https://github.com/celo-org/celo-monorepo/commit/0d433bc6b3bb0845868660281320d0a4fbba3dee
