### PR TITLE
feat: add currencyapi adapter

### DIFF
--- a/src/data_aggregator.ts
+++ b/src/data_aggregator.ts
@@ -1,7 +1,3 @@
-import { strict as assert } from 'assert'
-import BigNumber from 'bignumber.js'
-import Logger from 'bunyan'
-
 import * as aggregators from './aggregator_functions'
 
 import {
@@ -23,6 +19,7 @@ import {
 import { PriceSource, WeightedPrice } from './price_source'
 
 import { AlphavantageAdapter } from './exchange_adapters/alphavantage'
+import BigNumber from 'bignumber.js'
 import { BinanceAdapter } from './exchange_adapters/binance'
 import { BinanceUSAdapter } from './exchange_adapters/binance_us'
 import { BitMartAdapter } from './exchange_adapters/bitmart'
@@ -31,9 +28,11 @@ import { BitsoAdapter } from './exchange_adapters/bitso'
 import { BitstampAdapter } from './exchange_adapters/bitstamp'
 import { BittrexAdapter } from './exchange_adapters/bittrex'
 import { CoinbaseAdapter } from './exchange_adapters/coinbase'
+import { CurrencyApiAdapter } from './exchange_adapters/currencyapi'
 import { GeminiAdapter } from './exchange_adapters/gemini'
 import { KrakenAdapter } from './exchange_adapters/kraken'
 import { KuCoinAdapter } from './exchange_adapters/kucoin'
+import Logger from 'bunyan'
 import { MercadoAdapter } from './exchange_adapters/mercado'
 import { MetricCollector } from './metric_collector'
 import { NovaDaxAdapter } from './exchange_adapters/novadax'
@@ -41,6 +40,7 @@ import { OKCoinAdapter } from './exchange_adapters/okcoin'
 import { OKXAdapter } from './exchange_adapters/okx'
 import { OracleApplicationConfig } from './app'
 import { WhitebitAdapter } from './exchange_adapters/whitebit'
+import { strict as assert } from 'assert'
 
 function adapterFromExchangeName(name: Exchange, config: ExchangeAdapterConfig): ExchangeAdapter {
   switch (name) {
@@ -78,6 +78,8 @@ function adapterFromExchangeName(name: Exchange, config: ExchangeAdapterConfig):
       return new BitMartAdapter(config)
     case Exchange.ALPHAVANTAGE:
       return new AlphavantageAdapter(config)
+    case Exchange.CURRENCYAPI:
+      return new CurrencyApiAdapter(config)
   }
 }
 

--- a/src/exchange_adapters/currencyapi.ts
+++ b/src/exchange_adapters/currencyapi.ts
@@ -34,36 +34,35 @@ export class CurrencyApiAdapter extends BaseExchangeAdapter implements ExchangeA
   /**
    *
    * @param json parsed response from CurrencyApi latest endpoint
-    {
-      "meta": {
-        "last_updated_at": "2023-09-08T09:36:59Z"
-      },
-      "data": {
-        "XOF": {
-          "code": "XOF",
-          "value": 655.8426513119
-        }
-      }
-    }
+   * {
+   *   "meta": {
+   *    "last_updated_at": "2023-09-08T09:36:59Z"
+   *   },
+   *   "data": {
+   *     "XOF": {
+   *       "code": "XOF",
+   *       "value": 655.8426513119
+   *     }
+   *   }
+   * }
    */
   parseTicker(json: any): Ticker {
-    const response = json['data']
     assert(
-      Object.keys(response).includes(this.config.quoteCurrency),
+      Object.keys(json.data).includes(this.config.quoteCurrency),
       'CurrencyApi response does not contain quote currency'
     )
     assert(
-      json['meta']['last_updated_at'] !== undefined,
+      json.meta.last_updated_at !== undefined,
       'CurrencyApi response does not contain timestamp'
     )
 
-    const price = this.safeBigNumberParse(response[this.config.quoteCurrency]['value'])!
+    const price = this.safeBigNumberParse(json.data[this.config.quoteCurrency].value)!
     const ticker = {
       ...this.priceObjectMetadata,
       ask: price,
       bid: price,
       lastPrice: price,
-      timestamp: this.safeDateParse(json['meta']['last_updated_at'])! / 1000,
+      timestamp: this.safeDateParse(json.meta.last_updated_at)! / 1000,
       // These FX API's do not provide volume data,
       // therefore we set all of them to 1 to weight them equally.
       baseVolume: new BigNumber(1),

--- a/src/exchange_adapters/currencyapi.ts
+++ b/src/exchange_adapters/currencyapi.ts
@@ -1,0 +1,80 @@
+import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
+
+import BigNumber from 'bignumber.js'
+import { Exchange } from '../utils'
+import { strict as assert } from 'assert'
+
+export class CurrencyApiAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
+  baseApiUrl = 'https://api.currencyapi.com/v3'
+  readonly _exchangeName: Exchange = Exchange.CURRENCYAPI
+  // currencyapi.com - validity not after: 21/11/2023, 22:54:40 CET
+  readonly _certFingerprint256 =
+    '06:70:90:2E:07:43:A3:8C:25:2F:C4:35:F7:C4:F5:3A:12:9D:66:9A:95:6B:DC:C1:54:C1:FC:6A:BA:3B:B5:36'
+
+  protected generatePairSymbol(): string {
+    const base = CurrencyApiAdapter.standardTokenSymbolMap.get(this.config.baseCurrency)
+    const quote = CurrencyApiAdapter.standardTokenSymbolMap.get(this.config.quoteCurrency)
+
+    return `${base}${quote}`
+  }
+
+  async fetchTicker(): Promise<Ticker> {
+    assert(this.config.apiKey !== undefined, 'CurrencyApi API key was not set')
+
+    const base = this.config.baseCurrency
+    const quote = this.config.quoteCurrency
+
+    const tickerJson: Response = await this.fetchFromApi(
+      ExchangeDataType.TICKER,
+      `latest?base_currency=${base}&currencies=${quote}&apikey=${this.config.apiKey}`
+    )
+    return this.parseTicker(tickerJson)
+  }
+
+  /**
+   *
+   * @param json parsed response from CurrencyApi latest endpoint
+    {
+      "meta": {
+        "last_updated_at": "2023-09-08T09:36:59Z"
+      },
+      "data": {
+        "XOF": {
+          "code": "XOF",
+          "value": 655.8426513119
+        }
+      }
+    }
+   */
+  parseTicker(json: any): Ticker {
+    const response = json['data']
+    assert(
+      Object.keys(response).includes(this.config.quoteCurrency),
+      'CurrencyApi response does not contain quote currency'
+    )
+    assert(
+      json['meta']['last_updated_at'] !== undefined,
+      'CurrencyApi response does not contain timestamp'
+    )
+
+    const price = this.safeBigNumberParse(response[this.config.quoteCurrency]['value'])!
+    const ticker = {
+      ...this.priceObjectMetadata,
+      ask: price,
+      bid: price,
+      lastPrice: price,
+      timestamp: this.safeDateParse(json['meta']['last_updated_at'])! / 1000,
+      // These FX API's do not provide volume data,
+      // therefore we set all of them to 1 to weight them equally.
+      baseVolume: new BigNumber(1),
+      quoteVolume: price, // baseVolume * lastPrice, so 1 * lastPrice in this case
+    }
+    this.verifyTicker(ticker)
+    return ticker
+  }
+
+  async isOrderbookLive(): Promise<boolean> {
+    // TODO: implement later once we have defined the weekend conditions for FX adapters.
+    return true
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,7 @@ export enum Exchange {
   BITGET = 'BITGET',
   BITMART = 'BITMART',
   ALPHAVANTAGE = 'ALPHAVANTAGE',
+  CURRENCYAPI = 'CURRENCYAPI',
 }
 
 export enum ExternalCurrency {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,6 +89,7 @@ export enum OracleCurrencyPair {
   EUROCUSD = 'EUROCUSD',
   EURXOF = 'EURXOF',
   USDXOF = 'USDXOF',
+  EUROCXOF = 'EUROCXOF',
 }
 
 export const CoreCurrencyPair: OracleCurrencyPair[] = [
@@ -132,6 +133,7 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.EUROCUSD]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.USD },
   [OracleCurrencyPair.EURXOF]: { base: ExternalCurrency.EUR, quote: ExternalCurrency.XOF },
   [OracleCurrencyPair.USDXOF]: { base: ExternalCurrency.USD, quote: ExternalCurrency.XOF },
+  [OracleCurrencyPair.EUROCXOF]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.XOF },
 }
 
 export enum AggregationMethod {

--- a/test/exchange_adapters/currencyapi.test.ts
+++ b/test/exchange_adapters/currencyapi.test.ts
@@ -1,0 +1,83 @@
+import { Exchange, ExternalCurrency } from '../../src/utils'
+
+import BigNumber from 'bignumber.js'
+import { CurrencyApiAdapter } from '../../src/exchange_adapters/currencyapi'
+import { ExchangeAdapterConfig } from '../../src/exchange_adapters/base'
+import { baseLogger } from '../../src/default_config'
+
+describe('CurrencyApi adapter', () => {
+  let adapter: CurrencyApiAdapter
+
+  const config: ExchangeAdapterConfig = {
+    baseCurrency: ExternalCurrency.EUR,
+    baseLogger,
+    quoteCurrency: ExternalCurrency.XOF,
+  }
+
+  beforeEach(() => {
+    adapter = new CurrencyApiAdapter(config)
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.clearAllMocks()
+  })
+
+  const validMockTickerJson = {
+    meta: {
+      last_updated_at: '2023-09-08T10:26:59Z',
+    },
+    data: {
+      XOF: {
+        code: 'XOF',
+        value: 655.9185006503,
+      },
+    },
+  }
+
+  const invalidJsonWithNoQuoteCurrency = {
+    ...validMockTickerJson,
+    data: {
+      USD: {
+        code: 'USD',
+        value: 1.0,
+      },
+    },
+  }
+
+  const invalidJsonWithNoTimestamp = {
+    ...validMockTickerJson,
+    meta: {
+      last_updated_at: undefined,
+    },
+  }
+
+  describe('parseTicker', () => {
+    it('handles a response that matches the documentation', () => {
+      const ticker = adapter.parseTicker(validMockTickerJson)
+
+      expect(ticker).toEqual({
+        source: Exchange.CURRENCYAPI,
+        symbol: adapter.standardPairSymbol,
+        ask: new BigNumber(655.9185006503),
+        bid: new BigNumber(655.9185006503),
+        lastPrice: new BigNumber(655.9185006503),
+        timestamp: 1694168819,
+        baseVolume: new BigNumber(1),
+        quoteVolume: new BigNumber(655.9185006503),
+      })
+    })
+
+    it('throws an error when the quote currency is not in the response', () => {
+      expect(() => {
+        adapter.parseTicker(invalidJsonWithNoQuoteCurrency)
+      }).toThrowError('CurrencyApi response does not contain quote currency')
+    })
+
+    it('throws an error when the timestamp is not in the response', () => {
+      expect(() => {
+        adapter.parseTicker(invalidJsonWithNoTimestamp as any)
+      }).toThrowError('CurrencyApi response does not contain timestamp')
+    })
+  })
+})


### PR DESCRIPTION
## Description

This adds a second FX adapter (CurrencyAPI) which will be used for EURXOF rates. The logic for `isOrderbookLive` will be done in a different PR once we have the conditions defined.

## Other changes
N/A

## Tested

- Wrote unit tests for the parsing of the ticker
- Ran it locally to ensure it works

## Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/309
