### PR TITLE
fix: changes on currencyapi adapter and update expired certs

### DIFF
--- a/src/exchange_adapters/alphavantage.ts
+++ b/src/exchange_adapters/alphavantage.ts
@@ -25,8 +25,9 @@ interface Response {
 export class AlphavantageAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://www.alphavantage.co'
   readonly _exchangeName: Exchange = Exchange.ALPHAVANTAGE
+  // alphavantage.co - validity not after: 16/12/2023, 01:59:54 CET
   readonly _certFingerprint256 =
-    '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
+    'E3:0F:48:D9:B0:5B:B6:69:45:1A:45:4A:D8:C7:98:09:04:32:AB:28:53:5D:E0:10:0B:C1:3F:38:06:4C:6F:15'
 
   protected generatePairSymbol(): string {
     const base = AlphavantageAdapter.standardTokenSymbolMap.get(this.config.baseCurrency)

--- a/src/exchange_adapters/currencyapi.ts
+++ b/src/exchange_adapters/currencyapi.ts
@@ -46,13 +46,13 @@ export class CurrencyApiAdapter extends BaseExchangeAdapter implements ExchangeA
    * }
    */
   parseTicker(json: any): Ticker {
-    assert (json.valid, 'CurrencyApi response object contains false valid field');
-    assert (json.conversion.amount === 1, 'CurrencyApi response object amount field is not 1')
-    assert (
+    assert(json.valid, 'CurrencyApi response object contains false valid field')
+    assert(json.conversion.amount === 1, 'CurrencyApi response object amount field is not 1')
+    assert(
       json.conversion.from === this.config.baseCurrency,
       'CurrencyApi response object from field does not match base currency'
-    );
-    assert (
+    )
+    assert(
       json.conversion.to === this.config.quoteCurrency,
       'CurrencyApi response object to field does not match quote currency'
     )

--- a/src/exchange_adapters/kucoin.ts
+++ b/src/exchange_adapters/kucoin.ts
@@ -7,7 +7,7 @@ export class KuCoinAdapter extends BaseExchangeAdapter implements ExchangeAdapte
   readonly _exchangeName = Exchange.KUCOIN
   // api.kucoin.com - validity not after: 09/02/2024, 00:59:59 CET
   readonly _certFingerprint256 =
-    '29:C6:B0:C0:DE:73:3C:CA:0B:57:7E:AF:C8:8F:19:D4:5E:15:51:24:76:6C:89:6D:D5:53:FC:B5:9C:FB:75:B9'
+    '3C:97:F9:C7:2D:C6:30:AF:FD:5A:91:8A:E8:3C:CE:75:70:C4:35:31:B3:46:61:54:B8:C1:1D:7F:81:2E:DB:58'
 
   private static readonly tokenSymbolMap = KuCoinAdapter.standardTokenSymbolMap
 

--- a/test/exchange_adapters/currencyapi.test.ts
+++ b/test/exchange_adapters/currencyapi.test.ts
@@ -24,14 +24,14 @@ describe('CurrencyApi adapter', () => {
   })
 
   const validMockTickerJson = {
-    "valid": true,
-    "updated": 1695168063,
-    "conversion": {
-      "amount": 1,
-      "from": "EUR",
-      "to": "XOF",
-      "result": 655.315694
-    }
+    valid: true,
+    updated: 1695168063,
+    conversion: {
+      amount: 1,
+      from: 'EUR',
+      to: 'XOF',
+      result: 655.315694,
+    },
   }
 
   const invalidJsonWithFalseValid = {

--- a/test/exchange_adapters/currencyapi.test.ts
+++ b/test/exchange_adapters/currencyapi.test.ts
@@ -24,31 +24,42 @@ describe('CurrencyApi adapter', () => {
   })
 
   const validMockTickerJson = {
-    meta: {
-      last_updated_at: '2023-09-08T10:26:59Z',
-    },
-    data: {
-      XOF: {
-        code: 'XOF',
-        value: 655.9185006503,
-      },
+    "valid": true,
+    "updated": 1695168063,
+    "conversion": {
+      "amount": 1,
+      "from": "EUR",
+      "to": "XOF",
+      "result": 655.315694
+    }
+  }
+
+  const invalidJsonWithFalseValid = {
+    ...validMockTickerJson,
+    valid: false,
+  }
+
+  const invalidJsonWithAmountNotOne = {
+    ...validMockTickerJson,
+    conversion: {
+      ...validMockTickerJson.conversion,
+      amount: 2,
     },
   }
 
-  const invalidJsonWithNoQuoteCurrency = {
+  const invalidJsonWithInvalidFrom = {
     ...validMockTickerJson,
-    data: {
-      USD: {
-        code: 'USD',
-        value: 1.0,
-      },
+    conversion: {
+      ...validMockTickerJson.conversion,
+      from: 'USD',
     },
   }
 
-  const invalidJsonWithNoTimestamp = {
+  const invalidJsonWithInvalidTo = {
     ...validMockTickerJson,
-    meta: {
-      last_updated_at: undefined,
+    conversion: {
+      ...validMockTickerJson.conversion,
+      to: 'USD',
     },
   }
 
@@ -59,25 +70,37 @@ describe('CurrencyApi adapter', () => {
       expect(ticker).toEqual({
         source: Exchange.CURRENCYAPI,
         symbol: adapter.standardPairSymbol,
-        ask: new BigNumber(655.9185006503),
-        bid: new BigNumber(655.9185006503),
-        lastPrice: new BigNumber(655.9185006503),
-        timestamp: 1694168819,
+        ask: new BigNumber(655.315694),
+        bid: new BigNumber(655.315694),
+        lastPrice: new BigNumber(655.315694),
+        timestamp: 1695168063,
         baseVolume: new BigNumber(1),
-        quoteVolume: new BigNumber(655.9185006503),
+        quoteVolume: new BigNumber(655.315694),
       })
     })
 
-    it('throws an error when the quote currency is not in the response', () => {
+    it('throws an error when the valid field in the response is false', () => {
       expect(() => {
-        adapter.parseTicker(invalidJsonWithNoQuoteCurrency)
-      }).toThrowError('CurrencyApi response does not contain quote currency')
+        adapter.parseTicker(invalidJsonWithFalseValid)
+      }).toThrowError('CurrencyApi response object contains false valid field')
     })
 
-    it('throws an error when the timestamp is not in the response', () => {
+    it('throws an error when the amount in the response is not 1', () => {
       expect(() => {
-        adapter.parseTicker(invalidJsonWithNoTimestamp as any)
-      }).toThrowError('CurrencyApi response does not contain timestamp')
+        adapter.parseTicker(invalidJsonWithAmountNotOne)
+      }).toThrowError('CurrencyApi response object amount field is not 1')
+    })
+
+    it('throws an error when the from field in the response is not the base currency', () => {
+      expect(() => {
+        adapter.parseTicker(invalidJsonWithInvalidFrom)
+      }).toThrowError('CurrencyApi response object from field does not match base currency')
+    })
+
+    it('throws an error when the to field in the response is not the quote currency', () => {
+      expect(() => {
+        adapter.parseTicker(invalidJsonWithInvalidTo)
+      }).toThrowError('CurrencyApi response object to field does not match quote currency')
     })
   })
 })


### PR DESCRIPTION
## Description

We will be using `currencyapi.net` instead of the .com version as it has higher rate limits. 

## Other changes

- Update the certificate for alphavantage and kucoin that seems to have been recently updated

## Tested

Unit tests + ran both adapters locally
