### PR TITLE
feat: add market closing hours check on fx adapters

### DIFF
--- a/src/exchange_adapters/alphavantage.ts
+++ b/src/exchange_adapters/alphavantage.ts
@@ -38,6 +38,7 @@ export class AlphavantageAdapter extends BaseExchangeAdapter implements Exchange
 
   async fetchTicker(): Promise<Ticker> {
     assert(this.config.apiKey !== undefined, 'Alphavantage API key was not set')
+    this.setFxMarketStatus()
 
     const base = this.config.baseCurrency
     const quote = this.config.quoteCurrency
@@ -100,6 +101,13 @@ export class AlphavantageAdapter extends BaseExchangeAdapter implements Exchange
     }
     this.verifyTicker(ticker)
     return ticker
+  }
+
+  private setFxMarketStatus(): void {
+    const pair = this.generatePairSymbol()
+    const isMarketOpen = !BaseExchangeAdapter.fxMarketsClosed(Date.now())
+
+    this.config.metricCollector?.fxMarketsOpen(pair, isMarketOpen)
   }
 
   async isOrderbookLive(): Promise<boolean> {

--- a/src/exchange_adapters/alphavantage.ts
+++ b/src/exchange_adapters/alphavantage.ts
@@ -38,7 +38,6 @@ export class AlphavantageAdapter extends BaseExchangeAdapter implements Exchange
 
   async fetchTicker(): Promise<Ticker> {
     assert(this.config.apiKey !== undefined, 'Alphavantage API key was not set')
-    this.setFxMarketStatus()
 
     const base = this.config.baseCurrency
     const quote = this.config.quoteCurrency
@@ -101,13 +100,6 @@ export class AlphavantageAdapter extends BaseExchangeAdapter implements Exchange
     }
     this.verifyTicker(ticker)
     return ticker
-  }
-
-  private setFxMarketStatus(): void {
-    const pair = this.generatePairSymbol()
-    const isMarketOpen = !BaseExchangeAdapter.fxMarketsClosed(Date.now())
-
-    this.config.metricCollector?.fxMarketsOpen(pair, isMarketOpen)
   }
 
   async isOrderbookLive(): Promise<boolean> {

--- a/src/exchange_adapters/alphavantage.ts
+++ b/src/exchange_adapters/alphavantage.ts
@@ -103,6 +103,6 @@ export class AlphavantageAdapter extends BaseExchangeAdapter implements Exchange
   }
 
   async isOrderbookLive(): Promise<boolean> {
-    return true
+    return !BaseExchangeAdapter.fxMarketsClosed(Date.now())
   }
 }

--- a/src/exchange_adapters/base.ts
+++ b/src/exchange_adapters/base.ts
@@ -374,4 +374,25 @@ export abstract class BaseExchangeAdapter {
       },
     })
   }
+
+  /**
+   * A helper function that returns whether a given timestamp is within FX markets closing hours, meaning that
+   * they are closed and clients shouldn't report FX rates.
+   *
+   * The closing hours are: [Friday 22:00 UTC, Sunday 22:00 UTC)
+   *
+   * @param timestampInMs the timestamp in milliseconds to check
+   * @returns whether the FX markets are closed or not
+   */
+  static fxMarketsClosed(timestampInMs: number): boolean {
+    const date = new Date(timestampInMs)
+    const day = date.getUTCDay() // 0 for Sunday, 1 for Monday, 2 for Tuesday, and so on
+    const hour = date.getUTCHours() // 24h format
+
+    const isFridayEvening = day === 5 && hour >= 22
+    const isSaturday = day === 6
+    const isSundayBeforeEvening = day === 0 && hour < 22
+
+    return isFridayEvening || isSaturday || isSundayBeforeEvening
+  }
 }

--- a/src/exchange_adapters/currencyapi.ts
+++ b/src/exchange_adapters/currencyapi.ts
@@ -74,7 +74,6 @@ export class CurrencyApiAdapter extends BaseExchangeAdapter implements ExchangeA
   }
 
   async isOrderbookLive(): Promise<boolean> {
-    // TODO: implement later once we have defined the weekend conditions for FX adapters.
-    return true
+    return !BaseExchangeAdapter.fxMarketsClosed(Date.now())
   }
 }

--- a/src/exchange_adapters/currencyapi.ts
+++ b/src/exchange_adapters/currencyapi.ts
@@ -20,6 +20,7 @@ export class CurrencyApiAdapter extends BaseExchangeAdapter implements ExchangeA
 
   async fetchTicker(): Promise<Ticker> {
     assert(this.config.apiKey !== undefined, 'CurrencyApi API key was not set')
+    this.setFxMarketStatus()
 
     const base = this.config.baseCurrency
     const quote = this.config.quoteCurrency
@@ -71,6 +72,13 @@ export class CurrencyApiAdapter extends BaseExchangeAdapter implements ExchangeA
     }
     this.verifyTicker(ticker)
     return ticker
+  }
+
+  private setFxMarketStatus(): void {
+    const pair = this.generatePairSymbol()
+    const isMarketOpen = !BaseExchangeAdapter.fxMarketsClosed(Date.now())
+
+    this.config.metricCollector?.fxMarketsOpen(pair, isMarketOpen)
   }
 
   async isOrderbookLive(): Promise<boolean> {

--- a/src/exchange_adapters/currencyapi.ts
+++ b/src/exchange_adapters/currencyapi.ts
@@ -20,7 +20,6 @@ export class CurrencyApiAdapter extends BaseExchangeAdapter implements ExchangeA
 
   async fetchTicker(): Promise<Ticker> {
     assert(this.config.apiKey !== undefined, 'CurrencyApi API key was not set')
-    this.setFxMarketStatus()
 
     const base = this.config.baseCurrency
     const quote = this.config.quoteCurrency
@@ -72,13 +71,6 @@ export class CurrencyApiAdapter extends BaseExchangeAdapter implements ExchangeA
     }
     this.verifyTicker(ticker)
     return ticker
-  }
-
-  private setFxMarketStatus(): void {
-    const pair = this.generatePairSymbol()
-    const isMarketOpen = !BaseExchangeAdapter.fxMarketsClosed(Date.now())
-
-    this.config.metricCollector?.fxMarketsOpen(pair, isMarketOpen)
   }
 
   async isOrderbookLive(): Promise<boolean> {

--- a/src/metric_collector.ts
+++ b/src/metric_collector.ts
@@ -57,8 +57,6 @@ export class MetricCollector {
 
   private lastBlockHeaderNumberGauge: Gauge<string>
 
-  private fxMarketsOpenGauge: Gauge<string>
-
   private oracleBalanceValueGauge: Gauge<string>
 
   private potentialReportValueGauge: Gauge<string>
@@ -115,12 +113,6 @@ export class MetricCollector {
       name: 'oracle_last_block_header_number',
       help: 'Gauge to indicate the last block number seen when using block based reporting',
       labelNames: ['type'],
-    })
-
-    this.fxMarketsOpenGauge = new Gauge({
-      name: 'oracle_fx_markets_open',
-      help: 'Gauge to indicate whether FX markets are open (1) or not (0)',
-      labelNames: ['pair'],
     })
 
     this.oracleBalanceValueGauge = new Gauge({
@@ -344,10 +336,6 @@ export class MetricCollector {
    */
   blockHeaderNumber(type: BlockType, blockNumber: number) {
     this.lastBlockHeaderNumberGauge.set({ type }, blockNumber)
-  }
-
-  fxMarketsOpen(pair: string, value: boolean) {
-    this.fxMarketsOpenGauge.set({ pair }, Number(value))
   }
 
   oracleBalanceValue(oracleAddress: string, balance: number) {

--- a/src/metric_collector.ts
+++ b/src/metric_collector.ts
@@ -57,6 +57,8 @@ export class MetricCollector {
 
   private lastBlockHeaderNumberGauge: Gauge<string>
 
+  private fxMarketsOpenGauge: Gauge<string>
+
   private oracleBalanceValueGauge: Gauge<string>
 
   private potentialReportValueGauge: Gauge<string>
@@ -113,6 +115,12 @@ export class MetricCollector {
       name: 'oracle_last_block_header_number',
       help: 'Gauge to indicate the last block number seen when using block based reporting',
       labelNames: ['type'],
+    })
+
+    this.fxMarketsOpenGauge = new Gauge({
+      name: 'oracle_fx_markets_open',
+      help: 'Gauge to indicate whether FX markets are open (1) or not (0)',
+      labelNames: ['pair'],
     })
 
     this.oracleBalanceValueGauge = new Gauge({
@@ -336,6 +344,10 @@ export class MetricCollector {
    */
   blockHeaderNumber(type: BlockType, blockNumber: number) {
     this.lastBlockHeaderNumberGauge.set({ type }, blockNumber)
+  }
+
+  fxMarketsOpen(pair: string, value: boolean) {
+    this.fxMarketsOpenGauge.set({ pair }, Number(value))
   }
 
   oracleBalanceValue(oracleAddress: string, balance: number) {

--- a/test/exchange_adapters/base.test.ts
+++ b/test/exchange_adapters/base.test.ts
@@ -142,4 +142,48 @@ describe('BaseExchangeAdapter', () => {
       })
     })
   })
+
+  describe('fxMarketsClosed', () => {
+    describe('in markets closed hours', () => {
+      it('returns true on Fridays after 22h', () => {
+        expect(BaseExchangeAdapter.fxMarketsClosed(1680906067000)).toBe(true) // Fri, 07 Apr 2023 22:21:07
+        expect(BaseExchangeAdapter.fxMarketsClosed(1695420000000)).toBe(true) // Fri, 22 Sep 2023 22:00:00
+        expect(BaseExchangeAdapter.fxMarketsClosed(1680909071000)).toBe(true) // Fri, 07 Apr 2023 23:11:11
+        expect(BaseExchangeAdapter.fxMarketsClosed(1695427199000)).toBe(true) // Fri, 22 Sep 2023 23:59:59
+      })
+      it('returns true the whole day on Saturday', () => {
+        expect(BaseExchangeAdapter.fxMarketsClosed(1683331200000)).toBe(true) // Sat, 06 May 2023 00:00:00
+        expect(BaseExchangeAdapter.fxMarketsClosed(1674290736000)).toBe(true) // Sat, 21 Jan 2023 08:45:36
+        expect(BaseExchangeAdapter.fxMarketsClosed(1679750316000)).toBe(true) // Sat, 25 Mar 2023 13:18:36
+        expect(BaseExchangeAdapter.fxMarketsClosed(1680393599000)).toBe(true) // Sat, 01 Apr 2023 23:59:59
+      })
+      it('returns true on Sunday before 22h', () => {
+        expect(BaseExchangeAdapter.fxMarketsClosed(1683417615000)).toBe(true) // Sun, 07 May 2023 00:00:15
+        expect(BaseExchangeAdapter.fxMarketsClosed(1687682715000)).toBe(true) // Sun, 25 Jun 2023 08:45:15
+        expect(BaseExchangeAdapter.fxMarketsClosed(1690148715000)).toBe(true) // Sun, 23 Jul 2023 21:45:15
+      })
+    })
+
+    describe('in markets open hours', () => {
+      it('returns false on Friday before 22h', () => {
+        expect(BaseExchangeAdapter.fxMarketsClosed(1679011200000)).toBe(false) // Fri, 17 Mar 2023 00:00:00
+        expect(BaseExchangeAdapter.fxMarketsClosed(1679649322000)).toBe(false) // Fri, 24 Mar 2023 09:15:22
+        expect(BaseExchangeAdapter.fxMarketsClosed(1687540510000)).toBe(false) // Fri, 22 Jun 2023 17:15:10
+        expect(BaseExchangeAdapter.fxMarketsClosed(1682114399000)).toBe(false) // Fri, 21 Apr 2023 21:59:59
+      })
+      it('returns false on Sunday after 22h', () => {
+        expect(BaseExchangeAdapter.fxMarketsClosed(1687730400000)).toBe(false) // Sun, 25 Jun 2023 22:00:00
+        expect(BaseExchangeAdapter.fxMarketsClosed(1696803439000)).toBe(false) // Sun, 08 Oct 2023 22:17:19
+        expect(BaseExchangeAdapter.fxMarketsClosed(1675641599000)).toBe(false) // Sun, 05 Feb 2023 23:59:59
+        expect(BaseExchangeAdapter.fxMarketsClosed(1679872500000)).toBe(false) // Sun, 26 Mar 2023 23:15:00
+      })
+      it('returns false other days of the week', () => {
+        expect(BaseExchangeAdapter.fxMarketsClosed(1696889159000)).toBe(false) // Mon, 09 Oct 2023 22:05:59
+        expect(BaseExchangeAdapter.fxMarketsClosed(1672784239000)).toBe(false) // Tue, 03 Jan 2023 22:17:19
+        expect(BaseExchangeAdapter.fxMarketsClosed(1693973159000)).toBe(false) // Wed, 06 Sep 2023 04:05:59
+        expect(BaseExchangeAdapter.fxMarketsClosed(1686268799000)).toBe(false) // Thu, 08 Jun 2023 23:59:59
+        expect(BaseExchangeAdapter.fxMarketsClosed(1676038639000)).toBe(false) // Fri, 10 Feb 2023 14:17:19
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Description

This adds an orderbook check on the fx adapters that essentially disables them from reporting while the markets are closed on the weekends. The clients will stop reporting on Fridays 22 UTC and re-enable on Sundays 22 UTC.

## Other changes

-

## Tested

- Unit tests for the function that establishes the closing hours, and try it locally

## Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/310
