### PR TITLE
chore: update all adapters to not use leaf certificate

### DIFF
--- a/src/exchange_adapters/alphavantage.ts
+++ b/src/exchange_adapters/alphavantage.ts
@@ -25,9 +25,9 @@ interface Response {
 export class AlphavantageAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://www.alphavantage.co'
   readonly _exchangeName: Exchange = Exchange.ALPHAVANTAGE
-  // alphavantage.co - validity not after: 16/12/2023, 01:59:54 CET
+  // E1 - validity not after: 15/09/2025, 13:00:00 GMT-3
   readonly _certFingerprint256 =
-    'E3:0F:48:D9:B0:5B:B6:69:45:1A:45:4A:D8:C7:98:09:04:32:AB:28:53:5D:E0:10:0B:C1:3F:38:06:4C:6F:15'
+    '46:49:4E:30:37:90:59:DF:18:BE:52:12:43:05:E6:06:FC:59:07:0E:5B:21:07:6C:E1:13:95:4B:60:51:7C:DA'
 
   protected generatePairSymbol(): string {
     const base = AlphavantageAdapter.standardTokenSymbolMap.get(this.config.baseCurrency)

--- a/src/exchange_adapters/base.ts
+++ b/src/exchange_adapters/base.ts
@@ -234,7 +234,7 @@ export abstract class BaseExchangeAdapter {
         agent: this.httpsAgent,
         follow: 20, // redirect limit
         // max body size in bytes - usually < 10 KB, except for Binance exchangeInfo endpoint which is ~1.4MB
-        size: megabytesToBytes(4),
+        size: megabytesToBytes(8),
         timeout: this.config.apiRequestTimeout, // resets on redirect
       })
     } catch (err) {

--- a/src/exchange_adapters/binance.ts
+++ b/src/exchange_adapters/binance.ts
@@ -5,9 +5,9 @@ import { Exchange } from '../utils'
 export class BinanceAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.binance.com/api/v3'
   readonly _exchangeName: Exchange = Exchange.BINANCE
-  // *.binance.com - validity not after: 17/02/2024, 00:59:59 CET
+  // GeoTrust RSA CA 2018 - validity not after: 06/11/2027, 09:23:45 GMT-3
   _certFingerprint256 =
-    '93:07:DE:DD:AF:3A:78:77:1D:B1:B7:68:3E:9F:18:8E:28:83:AE:A1:77:58:87:D4:5C:F6:F9:C8:71:1A:72:49'
+    '8C:C3:4E:11:C1:67:04:58:24:AD:E6:1C:49:07:A6:44:0E:DB:2C:43:98:E9:9C:11:2A:85:9D:66:1F:8E:2B:C7'
 
   private static readonly tokenSymbolMap = BinanceAdapter.standardTokenSymbolMap
 

--- a/src/exchange_adapters/binance_us.ts
+++ b/src/exchange_adapters/binance_us.ts
@@ -5,7 +5,7 @@ import { BinanceAdapter } from './binance'
 export class BinanceUSAdapter extends BinanceAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.binance.us/api/v3'
   readonly _exchangeName = Exchange.BINANCEUS
-  // *.binance.us - validity not after: 11/09/2024, 01:59:59 CEST
+  // GeoTrust TLS RSA CA G1 - validity not after: 02/11/2027, 09:23:37 GMT-3
   _certFingerprint256 =
-    '45:48:18:31:2F:B1:60:5F:70:EA:FA:B8:67:B1:A5:5A:05:96:BE:74:66:C7:60:E4:F7:AF:D3:3F:0A:2E:D9:32'
+    'C0:6E:30:7F:7C:FC:1D:32:FA:72:A4:C0:33:C8:7B:90:01:9A:F2:16:F0:77:5D:64:97:8A:2E:CA:6C:8A:23:0E'
 }

--- a/src/exchange_adapters/bitget.ts
+++ b/src/exchange_adapters/bitget.ts
@@ -6,9 +6,9 @@ export class BitgetAdapter extends BaseExchangeAdapter {
   baseApiUrl = 'https://api.bitget.com/api'
 
   readonly _exchangeName = Exchange.BITGET
-  // bitget.com - validity not after: 19/07/2024, 01:59:59 CEST
+  // 	Cloudflare Inc ECC CA-3 - validity not after: 31/12/2024, 19:59:59 GMT-4
   readonly _certFingerprint256 =
-    'D3:E0:89:44:CC:C6:CD:F9:74:FB:A0:6D:2F:A3:8F:CF:DA:BF:76:C6:11:05:49:54:B4:58:CC:1F:AB:6B:29:3E'
+    '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
 
   async fetchTicker(): Promise<Ticker> {
     return this.parseTicker(

--- a/src/exchange_adapters/bitmart.ts
+++ b/src/exchange_adapters/bitmart.ts
@@ -5,9 +5,9 @@ import { Exchange } from '../utils'
 export class BitMartAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api-cloud.bitmart.com'
   readonly _exchangeName = Exchange.BITMART
-  // *.bitmart.com - validity not after: 16/01/2024, 07:29:21 CET
+  // Go Daddy Secure Certificate Authority - G2 - validity not after: 03/05/2031, 04:00:00 GMT-3
   readonly _certFingerprint256 =
-    '9D:44:FC:FB:7F:D3:14:1E:3C:E7:DB:B1:BF:E2:60:6A:D2:96:C6:7C:10:C5:A9:1F:58:D3:58:C0:19:82:85:5A'
+    '97:3A:41:27:6F:FD:01:E0:27:A2:AA:D4:9E:34:C3:78:46:D3:E9:76:FF:6A:62:0B:67:12:E3:38:32:04:1A:A6'
   private static readonly tokenSymbolMap = BitMartAdapter.standardTokenSymbolMap
 
   protected generatePairSymbol(): string {

--- a/src/exchange_adapters/bitso.ts
+++ b/src/exchange_adapters/bitso.ts
@@ -5,9 +5,9 @@ import { Exchange } from '../utils'
 export class BitsoAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.bitso.com/api/v3'
   readonly _exchangeName = Exchange.BITSO
-  // bitso.com - validity not after: 24/04/2024, 01:59:59 CEST
+  // Cloudflare Inc ECC CA-3 - validity not after: 31/12/2024, 19:59:59 GMT-4
   readonly _certFingerprint256 =
-    'C3:BB:BC:A5:E0:10:2F:02:2C:46:A2:69:C2:EF:F7:29:D8:76:23:7E:69:AA:4B:1E:92:23:56:34:2A:3E:DB:91'
+    '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
 
   private static readonly tokenSymbolMap = BitsoAdapter.standardTokenSymbolMap
 

--- a/src/exchange_adapters/bitstamp.ts
+++ b/src/exchange_adapters/bitstamp.ts
@@ -5,9 +5,9 @@ import { Exchange } from '../utils'
 export class BitstampAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://www.bitstamp.net/api/v2'
   readonly _exchangeName = Exchange.BITSTAMP
-  // www.bitstamp.net - validity not after: 11/04/2024, 01:59:59 CEST
+  // DigiCert EV RSA CA G2 - validity not after: 02/07/2030, 09:42:50 GMT-3
   readonly _certFingerprint256 =
-    'B2:FC:1C:C5:2A:4A:B4:B0:26:4E:C4:32:B8:F4:F0:34:87:66:2B:FD:CE:A0:35:47:0D:F1:0B:1B:97:68:2B:1A'
+    '95:88:EF:74:19:9E:45:AC:EF:CC:CF:C0:C4:70:10:E9:F2:A3:7A:1D:D4:4C:61:A4:E1:C6:B3:34:DA:5A:F6:14'
 
   private static readonly tokenSymbolMap = BitstampAdapter.standardTokenSymbolMap
 

--- a/src/exchange_adapters/bittrex.ts
+++ b/src/exchange_adapters/bittrex.ts
@@ -5,9 +5,9 @@ import { Exchange } from '../utils'
 export class BittrexAdapter extends BaseExchangeAdapter {
   baseApiUrl = 'https://api.bittrex.com/v3'
   readonly _exchangeName = Exchange.BITTREX
-  // sni.cloudflaressl.com - validity not after: 29/04/2024, 01:59:59 CEST
+  // Cloudflare Inc ECC CA-3 - validity not after: 31/12/2024, 19:59:59 GMT-4
   readonly _certFingerprint256 =
-    '2C:50:CC:AA:9B:2E:BB:B7:E0:7B:3D:0A:5A:09:1D:33:4F:B2:AB:F2:C4:D3:76:5E:9E:AA:C8:0E:99:A3:30:F6'
+    '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
 
   private static readonly tokenSymbolMap = BittrexAdapter.standardTokenSymbolMap
 

--- a/src/exchange_adapters/coinbase.ts
+++ b/src/exchange_adapters/coinbase.ts
@@ -5,9 +5,9 @@ import { CeloContract } from '@celo/contractkit'
 
 export class CoinbaseAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.pro.coinbase.com'
-  // pro.coinbase.com - validity not after: 11/05/2024, 01:59:59 CEST
+  // pro.coinbase.com - validity not after: 31/12/2024, 19:59:59 GMT-4
   readonly _certFingerprint256 =
-    '7B:F6:47:3E:A0:5F:92:B1:9D:7B:03:6B:68:7F:FF:F7:34:69:45:A0:AB:5D:76:D6:94:63:2D:06:C0:65:3B:39'
+    '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
 
   readonly _exchangeName = Exchange.COINBASE
 

--- a/src/exchange_adapters/coinbase.ts
+++ b/src/exchange_adapters/coinbase.ts
@@ -5,7 +5,7 @@ import { CeloContract } from '@celo/contractkit'
 
 export class CoinbaseAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.pro.coinbase.com'
-  // pro.coinbase.com - validity not after: 31/12/2024, 19:59:59 GMT-4
+  // Cloudflare Inc ECC CA-3 - validity not after: 31/12/2024, 19:59:59 GMT-4
   readonly _certFingerprint256 =
     '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
 

--- a/src/exchange_adapters/currencyapi.ts
+++ b/src/exchange_adapters/currencyapi.ts
@@ -7,9 +7,9 @@ import { strict as assert } from 'assert'
 export class CurrencyApiAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://currencyapi.net/api/v1'
   readonly _exchangeName: Exchange = Exchange.CURRENCYAPI
-  // currencyapi.net - validity not after: 05/12/2023, 10:03:39 CET
+  // E1 - validity not after: 15/09/2025, 13:00:00 GMT-3
   readonly _certFingerprint256 =
-    '8D:75:15:7A:96:A9:DD:A6:1D:A8:EE:58:6D:7A:A2:8D:71:E4:9B:1B:3D:09:D8:F2:F2:C2:31:6E:CC:0A:82:A7'
+    '46:49:4E:30:37:90:59:DF:18:BE:52:12:43:05:E6:06:FC:59:07:0E:5B:21:07:6C:E1:13:95:4B:60:51:7C:DA'
 
   protected generatePairSymbol(): string {
     const base = CurrencyApiAdapter.standardTokenSymbolMap.get(this.config.baseCurrency)

--- a/src/exchange_adapters/gemini.ts
+++ b/src/exchange_adapters/gemini.ts
@@ -6,9 +6,9 @@ export class GeminiAdapter extends BaseExchangeAdapter {
   baseApiUrl = 'https://api.gemini.com/v1/'
 
   readonly _exchangeName = Exchange.GEMINI
-  // exchange.gemini.com - validity not after: 01/08/2024, 01:59:59 CEST
+  // Amazon RSA 2048 M02 - validity not after: 23/08/2030, 19:25:30 GMT-3
   readonly _certFingerprint256 =
-    'AD:D8:46:BA:A8:98:AA:55:D6:76:4A:7C:87:B2:5B:A2:9D:FC:AC:53:78:AB:E9:70:2B:6B:BF:2D:AF:A2:7C:D9'
+    'B0:F3:30:A3:1A:0C:50:98:7E:1C:3A:7B:B0:2C:2D:DA:68:29:91:D3:16:5B:51:7B:D4:4F:BA:4A:60:20:BD:94'
 
   async fetchTicker(): Promise<Ticker> {
     return this.parseTicker(

--- a/src/exchange_adapters/kraken.ts
+++ b/src/exchange_adapters/kraken.ts
@@ -8,9 +8,9 @@ export class KrakenAdapter extends BaseExchangeAdapter implements ExchangeAdapte
 
   private static readonly tokenSymbolMap = KrakenAdapter.standardTokenSymbolMap
 
-  // api.kraken.com - validity not after: 31/10/2023, 07:00:28 CET
+  // GTS CA 1P5 - validity not after: 29/09/2027, 21:00:42 GMT-3
   readonly _certFingerprint256 =
-    '9D:13:08:93:7F:E0:7B:D0:05:F0:6A:15:64:E6:9A:99:17:5D:19:FC:D1:FB:43:03:43:FF:0D:14:2E:71:E3:C6'
+    '97:D4:20:03:E1:32:55:29:46:09:7F:20:EF:95:5F:5B:1C:D5:70:AA:43:72:D7:80:03:3A:65:EF:BE:69:75:8D'
 
   protected generatePairSymbol(): string {
     const base = KrakenAdapter.tokenSymbolMap.get(this.config.baseCurrency)

--- a/src/exchange_adapters/kucoin.ts
+++ b/src/exchange_adapters/kucoin.ts
@@ -5,9 +5,9 @@ import { Exchange } from '../utils'
 export class KuCoinAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.kucoin.com'
   readonly _exchangeName = Exchange.KUCOIN
-  // api.kucoin.com - validity not after: 09/02/2024, 00:59:59 CET
+  // Cloudflare Inc ECC CA-3 - validity not after: 31/12/2024, 19:59:59 GMT-4
   readonly _certFingerprint256 =
-    '3C:97:F9:C7:2D:C6:30:AF:FD:5A:91:8A:E8:3C:CE:75:70:C4:35:31:B3:46:61:54:B8:C1:1D:7F:81:2E:DB:58'
+    '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
 
   private static readonly tokenSymbolMap = KuCoinAdapter.standardTokenSymbolMap
 

--- a/src/exchange_adapters/mercado.ts
+++ b/src/exchange_adapters/mercado.ts
@@ -5,9 +5,9 @@ import { Exchange } from '../utils'
 export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.mercadobitcoin.net/api/v4'
   readonly _exchangeName = Exchange.MERCADO
-  // sni.cloudflaressl.com - validity not after: 15/05/2024, 01:59:59 CEST
+  // Cloudflare Inc ECC CA-3 - validity not after: 31/12/2024, 19:59:59 GMT-4
   readonly _certFingerprint256 =
-    '7F:6A:C9:B9:72:50:32:78:06:49:38:B1:FC:85:0D:DA:FB:C8:90:1B:FD:A1:E1:B2:17:77:D8:E4:AD:26:0E:3E'
+    '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
 
   private static readonly tokenSymbolMap = MercadoAdapter.standardTokenSymbolMap
 

--- a/src/exchange_adapters/novadax.ts
+++ b/src/exchange_adapters/novadax.ts
@@ -5,9 +5,9 @@ import { Exchange } from '../utils'
 export class NovaDaxAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api.novadax.com/v1/market'
   readonly _exchangeName = Exchange.NOVADAX
-  // novadax.com - validity not after: 23/11/2023, 08:35:21 CET
+  // GTS CA 1P5 - validity not after: 29/09/2027, 21:00:42 GMT-3
   readonly _certFingerprint256 =
-    'D9:77:DB:83:A1:18:F5:C5:67:5E:2C:AC:FA:9E:CC:54:E6:AF:A7:92:5A:2B:FC:C9:7F:C3:E4:35:43:7A:5B:1D'
+    '97:D4:20:03:E1:32:55:29:46:09:7F:20:EF:95:5F:5B:1C:D5:70:AA:43:72:D7:80:03:3A:65:EF:BE:69:75:8D'
 
   private static readonly tokenSymbolMap = NovaDaxAdapter.standardTokenSymbolMap
 

--- a/src/exchange_adapters/okcoin.ts
+++ b/src/exchange_adapters/okcoin.ts
@@ -5,9 +5,9 @@ import { Exchange } from '../utils'
 export class OKCoinAdapter extends BaseExchangeAdapter {
   baseApiUrl = 'https://www.okcoin.com/api'
 
-  // sni.cloudflaressl.com - validity not after: 29/04/2024, 01:59:59 CEST
+  // Cloudflare Inc ECC CA-3 - validity not after: 31/12/2024, 19:59:59 GMT-4
   readonly _certFingerprint256 =
-    '30:EB:DD:1F:AD:08:6E:6B:23:D1:94:03:99:BE:B7:CB:15:A5:F1:F8:AB:74:75:FF:B0:00:39:B7:73:9A:FE:BB'
+    '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
 
   readonly _exchangeName = Exchange.OKCOIN
 

--- a/src/exchange_adapters/okx.ts
+++ b/src/exchange_adapters/okx.ts
@@ -5,9 +5,9 @@ import { Exchange } from '../utils'
 export class OKXAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://www.okx.com/api/v5'
   readonly _exchangeName = Exchange.OKX
-  // www.okx.com - validity not after: 02/11/2023, 00:59:59 CET
+  // Cloudflare Inc ECC CA-3 - validity not after: 31/12/2024, 19:59:59 GMT-4
   readonly _certFingerprint256 =
-    '2A:31:F1:82:DB:EA:F4:E0:C7:B0:9F:60:25:0A:D3:F3:85:04:AE:9B:92:F1:B9:8E:C8:22:1F:E7:7B:C3:A6:66'
+    '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
 
   private static readonly tokenSymbolMap = OKXAdapter.standardTokenSymbolMap
 

--- a/src/exchange_adapters/whitebit.ts
+++ b/src/exchange_adapters/whitebit.ts
@@ -5,7 +5,7 @@ import { Exchange } from '../utils'
 export class WhitebitAdapter extends BaseExchangeAdapter {
   baseApiUrl = 'https://whitebit.com/api/v4/public/'
   readonly _exchangeName = Exchange.WHITEBIT
-  // Cloudflare Inc ECC CA-3
+  // Cloudflare Inc ECC CA-3 - validity not after: 31/12/2024, 19:59:59 GMT-4
   readonly _certFingerprint256 =
     '3A:BB:E6:3D:AF:75:6C:50:16:B6:B8:5F:52:01:5F:D8:E8:AC:BE:27:7C:50:87:B1:27:A6:05:63:A8:41:ED:8A'
 

--- a/src/exchange_adapters/xignite.ts
+++ b/src/exchange_adapters/xignite.ts
@@ -7,9 +7,9 @@ import { strict as assert } from 'assert'
 export class XigniteAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://globalcurrencies.xignite.com/xGlobalCurrencies.json'
   readonly _exchangeName: Exchange = Exchange.XIGNITE
-  // *.xignite.com - validity not after: 30/01/2024, 19:59:59 GMT-4
+  // Amazon RSA 2048 M02 - validity not after: 23/08/2030, 19:25:30 GMT-3
   readonly _certFingerprint256 =
-    'AC:3B:21:EB:EE:92:8B:81:85:EF:85:DF:76:DE:9A:A0:2C:06:3D:D0:48:89:F2:29:76:9F:AB:E1:69:3A:D4:F4'
+    'B0:F3:30:A3:1A:0C:50:98:7E:1C:3A:7B:B0:2C:2D:DA:68:29:91:D3:16:5B:51:7B:D4:4F:BA:4A:60:20:BD:94'
 
   protected generatePairSymbol(): string {
     const base = XigniteAdapter.standardTokenSymbolMap.get(this.config.baseCurrency)


### PR DESCRIPTION
## Description

This essentially reverts the change made in https://github.com/celo-org/celo-oracle/pull/186, as we realized that the leaf certificates are updated too often in some of the adapters which then causes them to stop working.

## Other changes

While testing the adapters I realized that Binance Intl is no longer working since the /exchangeInfo endpoint returns a response that matches our hardcoded max response size (4MB), so I increased that value to 8MB instead.

## Tested

Ran all the currently deployed charts locally and verified that none of them throw certificate related errors.

## Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/325
