### PR TITLE
fix: pin Docker image to node:18.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # docker push oracletest.azurecr.io/test/oracle:$COMMIT_SHA
 
 # First stage, builder to install devDependencies to build TypeScript
-FROM node:18 as BUILDER
+FROM node:18.18.0 as BUILDER
 
 RUN apt-get update
 RUN apt-get install -y libusb-1.0-0-dev


### PR DESCRIPTION
## Description

The Docker image started from `node:18` which is an ephemeral tag that gets update to the most recent `18.*.*` version.
Recently `18.18.2` was pushed but a dependency is having trouble because it can't find pre-built binaries for that version and building them in the Docker build is failing.

Solution: pin the node version at `18.18.0`

## Other changes

N/A

## Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

## Related issues

- Fixes #[issue number here]

## Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
