### PR TITLE
New PriceSource EUROCUSDT

### DIFF
--- a/src/exchange_adapters/bitmart.ts
+++ b/src/exchange_adapters/bitmart.ts
@@ -1,14 +1,20 @@
 import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
 
-import { Exchange } from '../utils'
+import {Currency,  Exchange, ExternalCurrency } from '../utils'
 
 export class BitMartAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api-cloud.bitmart.com'
   readonly _exchangeName = Exchange.BITMART
   // Go Daddy Secure Certificate Authority - G2 - validity not after: 03/05/2031, 04:00:00 GMT-3
   readonly _certFingerprint256 =
-    '97:3A:41:27:6F:FD:01:E0:27:A2:AA:D4:9E:34:C3:78:46:D3:E9:76:FF:6A:62:0B:67:12:E3:38:32:04:1A:A6'
-  private static readonly tokenSymbolMap = BitMartAdapter.standardTokenSymbolMap
+    '9D:44:FC:FB:7F:D3:14:1E:3C:E7:DB:B1:BF:E2:60:6A:D2:96:C6:7C:10:C5:A9:1F:58:D3:58:C0:19:82:85:5A'
+  
+  /**
+   * Bitmart is currently using `EURC` as the symbol for EUROC. 
+   */
+    private static readonly tokenSymbolMap = new Map<Currency, string>([
+    ...BitMartAdapter.standardTokenSymbolMap,
+    [ExternalCurrency.EUROC, 'EURC'],])
 
   protected generatePairSymbol(): string {
     return `${BitMartAdapter.tokenSymbolMap.get(
@@ -16,7 +22,7 @@ export class BitMartAdapter extends BaseExchangeAdapter implements ExchangeAdapt
     )}_${BitMartAdapter.tokenSymbolMap.get(this.config.quoteCurrency)}`
   }
 
-  async fetchTicker(): Promise<Ticker> {
+  async fetchTicker(): Promise<Ticker> {    
     const tickerJson = await this.fetchFromApi(
       ExchangeDataType.TICKER,
       `spot/v1/ticker_detail?symbol=${this.pairSymbol}`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,6 +91,7 @@ export enum OracleCurrencyPair {
   EURXOF = 'EURXOF',
   USDXOF = 'USDXOF',
   EUROCXOF = 'EUROCXOF',
+  EUROCUSDT = 'EUROCUSDT',
 }
 
 export const CoreCurrencyPair: OracleCurrencyPair[] = [
@@ -135,6 +136,7 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.EURXOF]: { base: ExternalCurrency.EUR, quote: ExternalCurrency.XOF },
   [OracleCurrencyPair.USDXOF]: { base: ExternalCurrency.USD, quote: ExternalCurrency.XOF },
   [OracleCurrencyPair.EUROCXOF]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.XOF },
+  [OracleCurrencyPair.EUROCUSDT]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.USDT },
 }
 
 export enum AggregationMethod {


### PR DESCRIPTION
## Description

This PR adds a new price source `EUROCUSDT`. 

## Other changes

- It renews the Bitmart fingerprint (but will also expire soon...)
- It adds a symbol map as Bitmart uses `EURC` instead of `EUROC`
## Tested

Has been tested locally.

## Related issues

- Fixes #[issue number here]

## Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
