### PR TITLE
feat: add price source EUROCUSDT

### DIFF
--- a/src/exchange_adapters/bitmart.ts
+++ b/src/exchange_adapters/bitmart.ts
@@ -1,14 +1,22 @@
 import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
 
-import { Exchange } from '../utils'
+import { Currency, Exchange, ExternalCurrency } from '../utils'
+
 
 export class BitMartAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api-cloud.bitmart.com'
   readonly _exchangeName = Exchange.BITMART
   // Go Daddy Secure Certificate Authority - G2 - validity not after: 03/05/2031, 04:00:00 GMT-3
   readonly _certFingerprint256 =
-    '97:3A:41:27:6F:FD:01:E0:27:A2:AA:D4:9E:34:C3:78:46:D3:E9:76:FF:6A:62:0B:67:12:E3:38:32:04:1A:A6'
-  private static readonly tokenSymbolMap = BitMartAdapter.standardTokenSymbolMap
+    '9D:44:FC:FB:7F:D3:14:1E:3C:E7:DB:B1:BF:E2:60:6A:D2:96:C6:7C:10:C5:A9:1F:58:D3:58:C0:19:82:85:5A'
+
+  /**
+   * Bitmart is currently using `EURC` as the symbol for EUROC.
+   */
+  private static readonly tokenSymbolMap = new Map<Currency, string>([
+    ...BitMartAdapter.standardTokenSymbolMap,
+    [ExternalCurrency.EUROC, 'EURC'],
+  ])
 
   protected generatePairSymbol(): string {
     return `${BitMartAdapter.tokenSymbolMap.get(

--- a/src/exchange_adapters/bitmart.ts
+++ b/src/exchange_adapters/bitmart.ts
@@ -2,7 +2,6 @@ import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from '
 
 import { Currency, Exchange, ExternalCurrency } from '../utils'
 
-
 export class BitMartAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
   baseApiUrl = 'https://api-cloud.bitmart.com'
   readonly _exchangeName = Exchange.BITMART

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,6 +91,7 @@ export enum OracleCurrencyPair {
   EURXOF = 'EURXOF',
   USDXOF = 'USDXOF',
   EUROCXOF = 'EUROCXOF',
+  EUROCUSDT = 'EUROCUSDT',
 }
 
 export const CoreCurrencyPair: OracleCurrencyPair[] = [
@@ -135,6 +136,8 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.EURXOF]: { base: ExternalCurrency.EUR, quote: ExternalCurrency.XOF },
   [OracleCurrencyPair.USDXOF]: { base: ExternalCurrency.USD, quote: ExternalCurrency.XOF },
   [OracleCurrencyPair.EUROCXOF]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.XOF },
+  [OracleCurrencyPair.EUROCUSDT]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.USDT },
+
 }
 
 export enum AggregationMethod {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,7 +137,6 @@ export const CurrencyPairBaseQuote: Record<
   [OracleCurrencyPair.USDXOF]: { base: ExternalCurrency.USD, quote: ExternalCurrency.XOF },
   [OracleCurrencyPair.EUROCXOF]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.XOF },
   [OracleCurrencyPair.EUROCUSDT]: { base: ExternalCurrency.EUROC, quote: ExternalCurrency.USDT },
-
 }
 
 export enum AggregationMethod {

--- a/test/exchange_adapters/bitmart.test.ts
+++ b/test/exchange_adapters/bitmart.test.ts
@@ -28,7 +28,7 @@ describe('BitMart adapter', () => {
     code: 1000,
     trace: '48cff315816f4e1aa26ca72cccb46051.58.16892401718550155',
     data: {
-      symbol: 'EUROC_USDC',
+      symbol: 'EURC_USDC',
       last_price: '1.10806017',
       quote_volume_24h: '91361.42293780',
       base_volume_24h: '82758.2',
@@ -42,7 +42,7 @@ describe('BitMart adapter', () => {
       best_bid_size: '55.2',
       fluctuation: '+0.0098',
       timestamp: 1689239976811,
-      url: 'https://www.bitmart.com/trade?symbol=EUROC_USDC',
+      url: 'https://www.bitmart.com/trade?symbol=EURC_USDC',
     },
   }
 
@@ -51,7 +51,7 @@ describe('BitMart adapter', () => {
     code: 1000,
     trace: '48cff315816f4e1aa26ca72cccb46051.58.16892401718550155',
     data: {
-      symbol: 'EUROC_USDC',
+      symbol: 'EURC_USDC',
       last_price: undefined,
       quote_volume_24h: '91361.42293780',
       base_volume_24h: undefined,
@@ -65,7 +65,7 @@ describe('BitMart adapter', () => {
       best_bid_size: '55.2',
       fluctuation: '+0.0098',
       timestamp: undefined,
-      url: 'https://www.bitmart.com/trade?symbol=EUROC_USDC',
+      url: 'https://www.bitmart.com/trade?symbol=EURC_USDC',
     },
   }
 
@@ -112,9 +112,9 @@ describe('BitMart adapter', () => {
           trade_status: '',
         },
         {
-          symbol: 'EUROC_USDC',
+          symbol: 'EURC_USDC',
           symbol_id: 2632,
-          base_currency: 'EUROC',
+          base_currency: 'EURC',
           quote_currency: 'USDC',
           quote_increment: '0.1',
           base_min_size: '0.100000000000000000000000000000',
@@ -150,9 +150,9 @@ describe('BitMart adapter', () => {
           trade_status: 'trading',
         },
         {
-          symbol: 'EUROC_USDC',
+          symbol: 'EURC_USDC',
           symbol_id: 2632,
-          base_currency: 'EUROC',
+          base_currency: 'EURC',
           quote_currency: 'USDC',
           quote_increment: '0.1',
           base_min_size: '0.100000000000000000000000000000',
@@ -188,9 +188,9 @@ describe('BitMart adapter', () => {
           trade_status: 'trading',
         },
         {
-          symbol: 'EUROC_XOF',
+          symbol: 'EURC_XOF',
           symbol_id: 2632,
-          base_currency: 'EUROC',
+          base_currency: 'EURC',
           quote_currency: 'USDC',
           quote_increment: '0.1',
           base_min_size: '0.100000000000000000000000000000',


### PR DESCRIPTION
## Description

This PR adds a new price source `EUROCUSDT`. 

## Other changes

- It renews the Bitmart fingerprint (but will also expire soon...)
- It adds a symbol map as Bitmart uses `EURC` instead of `EUROC`
## Tested

Has been tested locally.
