### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# Lines starting with '#' are comments.
-# Each line is a file pattern followed by one or more owners.
-# For details on acceptable file patterns, please refer to the [Github Documentation](https://help.github.com/articles/about-codeowners/)
-
-# default owners, overridden by directory specific owners below
-* @celo-org/platform-economics


### PR DESCRIPTION
## Description

The CODEOWNERS file does not reflect current ownership. Delete to avoid confusion.