### PR TITLE
fix: broken ws reconnection after web3 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest",
     "lint": "tslint -c tslint.json --project .",
     "lint:tests": "tslint -c tslint.json 'test/**/*.test.ts'",
-    "prettify": "pmpm prettier --config .prettierrc.js --write '**/*.+(ts|tsx|js|jsx|sol|java)'",
+    "prettify": "pnpm prettier --config .prettierrc.js --write '**/*.+(ts|tsx|js|jsx|sol|java)'",
     "prettify:diff": "pnpm prettier --config .prettierrc.js --list-different '**/*.+(ts|tsx|js|jsx|sol|java)'",
     "get-cert": "./scripts/get_cert_fingerprint.sh"
   },

--- a/src/reporters/block_based_reporter.ts
+++ b/src/reporters/block_based_reporter.ts
@@ -326,9 +326,9 @@ export class BlockBasedReporter extends BaseReporter {
       })
       await setupNewProviderAndSubs()
     })
-    this.provider.on('end', async () => {
+    this.provider.on('close', async () => {
       onError(
-        new Error('WebsocketProvider has ended, will restart'),
+        new Error('WebsocketProvider connection closed, will re-open'),
         this.blockHeaderSubscriptionErrorWrapper
       )
       await setupNewProviderAndSubs()

--- a/src/reporters/block_based_reporter.ts
+++ b/src/reporters/block_based_reporter.ts
@@ -88,6 +88,14 @@ export class BlockBasedReporter extends BaseReporter {
 
   readonly config: BlockBasedReporterConfig
 
+  readonly wsConnectionOptions = {
+    // to enable auto reconnection
+    reconnect: {
+      auto: true,
+      delay: 1000, // ms
+    },
+  };
+
   private _blockHeaderSubscription: Subscription<BlockHeader> | undefined
 
   private _highestObservedBlockNumber: number
@@ -112,7 +120,7 @@ export class BlockBasedReporter extends BaseReporter {
       metricCollector: this.config.metricCollector,
       swallowError: true,
     }
-    this.provider = new Web3.providers.WebsocketProvider(this.config.wsRpcProviderUrl)
+    this.provider = new Web3.providers.WebsocketProvider(this.config.wsRpcProviderUrl, this.wsConnectionOptions)
     this.web3 = new Web3(this.provider)
     this.initialized = false
   }
@@ -296,7 +304,7 @@ export class BlockBasedReporter extends BaseReporter {
 
   private setupProviderAndSubscriptions(): void {
     this.logger.info('Setting up wsProvider and subscriptions')
-    this.provider = new Web3.providers.WebsocketProvider(this.config.wsRpcProviderUrl)
+    this.provider = new Web3.providers.WebsocketProvider(this.config.wsRpcProviderUrl, this.wsConnectionOptions)
     this.web3.setProvider(this.provider)
     this.config.metricCollector?.websocketProviderSetup()
     let setupNewProvider = false

--- a/src/reporters/block_based_reporter.ts
+++ b/src/reporters/block_based_reporter.ts
@@ -318,6 +318,10 @@ export class BlockBasedReporter extends BaseReporter {
       setupNewProvider = true
     }
 
+    this.provider.on('reconnect', () => {
+      this.logger.info('Attempting to reconnect to WebsocketProvider...')
+    })
+
     // @ts-ignore - the type definition does not include the error
     this.provider.on('error', async (error: Error) => {
       onError(error, {

--- a/src/reporters/block_based_reporter.ts
+++ b/src/reporters/block_based_reporter.ts
@@ -94,7 +94,7 @@ export class BlockBasedReporter extends BaseReporter {
       auto: true,
       delay: 5000, // ms, roughly a block
     },
-  };
+  }
 
   private _blockHeaderSubscription: Subscription<BlockHeader> | undefined
 
@@ -120,7 +120,10 @@ export class BlockBasedReporter extends BaseReporter {
       metricCollector: this.config.metricCollector,
       swallowError: true,
     }
-    this.provider = new Web3.providers.WebsocketProvider(this.config.wsRpcProviderUrl, this.wsConnectionOptions)
+    this.provider = new Web3.providers.WebsocketProvider(
+      this.config.wsRpcProviderUrl,
+      this.wsConnectionOptions
+    )
     this.web3 = new Web3(this.provider)
     this.initialized = false
   }
@@ -304,7 +307,10 @@ export class BlockBasedReporter extends BaseReporter {
 
   private setupProviderAndSubscriptions(): void {
     this.logger.info('Setting up wsProvider and subscriptions')
-    this.provider = new Web3.providers.WebsocketProvider(this.config.wsRpcProviderUrl, this.wsConnectionOptions)
+    this.provider = new Web3.providers.WebsocketProvider(
+      this.config.wsRpcProviderUrl,
+      this.wsConnectionOptions
+    )
     this.web3.setProvider(this.provider)
     this.config.metricCollector?.websocketProviderSetup()
     let setupNewProvider = false

--- a/src/reporters/block_based_reporter.ts
+++ b/src/reporters/block_based_reporter.ts
@@ -92,7 +92,7 @@ export class BlockBasedReporter extends BaseReporter {
     // to enable auto reconnection
     reconnect: {
       auto: true,
-      delay: 1000, // ms
+      delay: 5000, // ms, roughly a block
     },
   };
 


### PR DESCRIPTION
## Description

This fixes the issue where the client WS connections no longer reconnect after an interruption due to the web3 library upgrade that was done in https://github.com/celo-org/celo-oracle/commit/28ecb4b2c8f78a9bda9ceb7ce0ad4d38d5d522c9. The fix is done by passing an options parameter that includes a reconnect configuration whenever we instantiate a new `WebsocketProvider`. It also adds a new `reconnect` listener so that the client can log whenever it's attempting to reconnect.

There are also a few other places in the code where a "manual reconnection" is attempted by re-instantiating `WebsocketProvider` ([1](https://github.com/celo-org/celo-oracle/blob/459947a5b697473f93f1389f37410dcd93a9ac74/src/reporters/block_based_reporter.ts#L331), [2](https://github.com/celo-org/celo-oracle/blob/459947a5b697473f93f1389f37410dcd93a9ac74/src/reporters/block_based_reporter.ts#L338), [3](https://github.com/celo-org/celo-oracle/blob/459947a5b697473f93f1389f37410dcd93a9ac74/src/reporters/block_based_reporter.ts#L348)) which I decided not to touch since I'm not sure under which conditions those listeners are hit. It would be good to look deeper into them at some point and re-evaluate which ones are needed.

Shoutout to @lvpeschke and @carterqw2 for debugging this issue 🙏  

## Other changes

Replaced the `end` event with `close` instead as the former doesn't exist in `WebsocketProvider` (unclear if it got deprecated at some point or if it was never there). See https://github.com/web3/web3.js/blob/1.x/packages/web3-providers-ws/src/index.js#L55-L59

## Tested

- Ran this locally next to a local lightnode and verified that the client correctly reconnects after stopping/restarting the lightnode several times.
- Currently deployed to Baklava and Alfajores