### PR TITLE
fix: EUROC to EURC renaming on Coinbase

### DIFF
--- a/src/exchange_adapters/coinbase.ts
+++ b/src/exchange_adapters/coinbase.ts
@@ -1,5 +1,5 @@
 import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from './base'
-import { Currency, Exchange } from '../utils'
+import { Currency, Exchange, ExternalCurrency } from '../utils'
 
 import { CeloContract } from '@celo/contractkit'
 
@@ -12,12 +12,12 @@ export class CoinbaseAdapter extends BaseExchangeAdapter implements ExchangeAdap
   readonly _exchangeName = Exchange.COINBASE
 
   /**
-   * Coinbase is currently using `CGLD` as the symbol for CELO. This is likely
-   * to be changed at some point after listing.
+   * Coinbase is currently using `CGLD` as the symbol for CELO and `EURC` as the symbol for EUROC.
    */
   private static readonly tokenSymbolMap = new Map<Currency, string>([
     ...CoinbaseAdapter.standardTokenSymbolMap,
     [CeloContract.GoldToken, 'CGLD'],
+    [ExternalCurrency.EUROC, 'EURC'],
   ])
 
   protected generatePairSymbol(): string {

--- a/test/exchange_adapters/base.test.ts
+++ b/test/exchange_adapters/base.test.ts
@@ -133,7 +133,7 @@ describe('BaseExchangeAdapter', () => {
         await expect(async () =>
           adapter.fetchFromApi(ExchangeDataType.TICKER, mockTickerEndpoint)
         ).rejects.toThrowError(
-          'Failed to parse JSON response: FetchError: invalid json response body at  reason: Unexpected token \'<\', "<html>blah"... is not valid JSON'
+          'Failed to parse JSON response: FetchError: invalid json response body at  reason: Unexpected token < in JSON at position 0'
         )
         expect(metricCollector.exchangeApiRequestError).toBeCalledWith(
           ...metricArgs,

--- a/test/exchange_adapters/base.test.ts
+++ b/test/exchange_adapters/base.test.ts
@@ -133,7 +133,7 @@ describe('BaseExchangeAdapter', () => {
         await expect(async () =>
           adapter.fetchFromApi(ExchangeDataType.TICKER, mockTickerEndpoint)
         ).rejects.toThrowError(
-          'Failed to parse JSON response: FetchError: invalid json response body at  reason: Unexpected token < in JSON at position 0'
+          'Failed to parse JSON response: FetchError: invalid json response body at  reason: Unexpected token \'<\', "<html>blah"... is not valid JSON'
         )
         expect(metricCollector.exchangeApiRequestError).toBeCalledWith(
           ...metricArgs,

--- a/test/exchange_adapters/coinbase.test.ts
+++ b/test/exchange_adapters/coinbase.test.ts
@@ -65,6 +65,29 @@ describe('CoinbaseAdapter', () => {
     })
   })
 
+  describe('using the non-standard symbol for EUROC', () => {
+    let coinbaseAdapter2: CoinbaseAdapter
+    const config2: ExchangeAdapterConfig = {
+      baseCurrency: ExternalCurrency.EUROC,
+      baseLogger,
+      quoteCurrency: ExternalCurrency.USD,
+    }
+
+    let fetchFromApiSpy: jest.SpyInstance
+    beforeEach(() => {
+      coinbaseAdapter2 = new CoinbaseAdapter(config2)
+      fetchFromApiSpy = jest.spyOn(coinbaseAdapter2, 'fetchFromApi')
+    })
+    it('uses the right symbols when fetching the ticker', async () => {
+      fetchFromApiSpy.mockReturnValue(Promise.resolve(mockTickerJson))
+      await coinbaseAdapter2.fetchTicker()
+      expect(fetchFromApiSpy).toHaveBeenCalledWith(
+        ExchangeDataType.TICKER,
+        'products/EURC-USD/ticker'
+      )
+    })
+  })
+
   describe('parseTicker', () => {
     it('handles a response that matches the documentation', () => {
       const ticker = coinbaseAdapter.parseTicker(mockTickerJson)


### PR DESCRIPTION
## Description

Coinbase recently renamed EUROC to EURC in tickers etc. 

## Other changes

One exchange adapter base test was failing because the expected error message changed. 

## Tested

Ran orcles locally with coinbase EUROC in the config. 

## Related issues



## Backwards compatibility


