### PR TITLE
fix: update certificates for binance, mercado and novadax

### DIFF
--- a/src/exchange_adapters/binance.ts
+++ b/src/exchange_adapters/binance.ts
@@ -3,11 +3,11 @@ import { BaseExchangeAdapter, ExchangeAdapter, ExchangeDataType, Ticker } from '
 import { Exchange } from '../utils'
 
 export class BinanceAdapter extends BaseExchangeAdapter implements ExchangeAdapter {
-  baseApiUrl = 'https://api.binance.com/api/v3'
+  baseApiUrl = 'https://data-api.binance.vision/api/v3'
   readonly _exchangeName: Exchange = Exchange.BINANCE
   // GeoTrust RSA CA 2018 - validity not after: 06/11/2027, 09:23:45 GMT-3
   _certFingerprint256 =
-    'C0:6E:30:7F:7C:FC:1D:32:FA:72:A4:C0:33:C8:7B:90:01:9A:F2:16:F0:77:5D:64:97:8A:2E:CA:6C:8A:23:0E'
+    'BF:8A:69:02:7B:CC:8D:2D:42:A6:E6:D2:5B:DD:48:73:F6:A3:4B:8F:90:ED:F0:7E:86:C5:D6:91:6D:A0:B9:33'
 
   private static readonly tokenSymbolMap = BinanceAdapter.standardTokenSymbolMap
 

--- a/src/exchange_adapters/mercado.ts
+++ b/src/exchange_adapters/mercado.ts
@@ -7,7 +7,7 @@ export class MercadoAdapter extends BaseExchangeAdapter implements ExchangeAdapt
   readonly _exchangeName = Exchange.MERCADO
   // Google Trust Services LLC CA - validity not after: 9/29/27, 7:00:42 PM EST
   readonly _certFingerprint256 =
-    '97:D4:20:03:E1:32:55:29:46:09:7F:20:EF:95:5F:5B:1C:D5:70:AA:43:72:D7:80:03:3A:65:EF:BE:69:75:8D'
+    '1D:FC:16:05:FB:AD:35:8D:8B:C8:44:F7:6D:15:20:3F:AC:9C:A5:C1:A7:9F:D4:85:7F:FA:F2:86:4F:BE:BF:96'
 
   private static readonly tokenSymbolMap = MercadoAdapter.standardTokenSymbolMap
 

--- a/src/exchange_adapters/novadax.ts
+++ b/src/exchange_adapters/novadax.ts
@@ -7,7 +7,7 @@ export class NovaDaxAdapter extends BaseExchangeAdapter implements ExchangeAdapt
   readonly _exchangeName = Exchange.NOVADAX
   // GTS CA 1P5 - validity not after: 29/09/2027, 21:00:42 GMT-3
   readonly _certFingerprint256 =
-    '97:D4:20:03:E1:32:55:29:46:09:7F:20:EF:95:5F:5B:1C:D5:70:AA:43:72:D7:80:03:3A:65:EF:BE:69:75:8D'
+    '1D:FC:16:05:FB:AD:35:8D:8B:C8:44:F7:6D:15:20:3F:AC:9C:A5:C1:A7:9F:D4:85:7F:FA:F2:86:4F:BE:BF:96'
 
   private static readonly tokenSymbolMap = NovaDaxAdapter.standardTokenSymbolMap
 


### PR DESCRIPTION
## Description

This PR updates certificates for mercado, binance, and novadax as well as the base endpoint for Binance. 
The updated base endpoint is recommended to be used when accessing public market data 

## Other changes

## Tested

Ran each of the updated adapters locally in dev mode.

## Related issues

## Backwards compatibility
